### PR TITLE
default to 0 if fees are negative.

### DIFF
--- a/src/components/PoolForm/PoolForm.tsx
+++ b/src/components/PoolForm/PoolForm.tsx
@@ -75,7 +75,10 @@ const PoolForm: FC<Props> = ({
           <PositionBlock>
             <PositionBlockItem>Fees earned</PositionBlockItem>
             <PositionBlockItem>
-              {formatUnits(feesEarned, decimals)} {symbol}
+              {Number(formatUnits(feesEarned, decimals)) < 0
+                ? formatUnits(feesEarned, decimals)
+                : "0.0000"}{" "}
+              {symbol}
             </PositionBlockItem>
           </PositionBlock>
           <PositionBlock>


### PR DESCRIPTION
https://app.shortcut.com/uma-project/story/2990/deposited-1-eth-in-the-pool-closed-the-confirmation-screen-and-it-showed-that-i-had-1-eth-as-fees-and-0-eth-as-my-deposit

Signed-off-by: Tulun <jaykiraly@gmail.com>