### PR TITLE
fix: increase gas estimate buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 ## Env variables
 
 - REACT_APP_PUBLIC_INFURA_ID: an infura ID used to set up providers
+- REACT_APP_PUBLIC_ONBOARD_API_KEY: onboard api key
+- REACT_APP_CONFIRMATIONS: how many confirms before we consider transaction mined
+- REACT_APP_GAS_PRICE_BUFFER: additional gas price to add to ensure enough buffer when sending max eth tx, specify in gwei
+- REACT_APP_DEFAULT_GAS_PRICE: default gas price estimate when no online estimate is available, specify in gwei
 
 ## Available Scripts
 

--- a/src/components/PoolForm/PoolForm.tsx
+++ b/src/components/PoolForm/PoolForm.tsx
@@ -78,10 +78,20 @@ const PoolForm: FC<Props> = ({
 
   const { isConnected, provider } = useConnection();
 
-  // TODO: move this to redux and update on an interval, every X blocks or something
   useEffect(() => {
     if (!provider || !isConnected) return;
-    getGasPrice(provider).then(setGasPrice);
+    getGasPrice(provider)
+      .then(setGasPrice)
+      .catch((err) => console.error("Error getting gas price", err));
+
+    // get gas price on an interval
+    const handle = setInterval(() => {
+      getGasPrice(provider)
+        .then(setGasPrice)
+        .catch((err) => console.error("Error getting gas price", err));
+    }, 30000);
+
+    return () => clearInterval(handle);
   }, [provider, isConnected]);
 
   const addLiquidityOnChangeHandler = (

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -508,7 +508,13 @@ export const RATE_MODELS: Record<string, RateModel> = {
 // this client requires multicall2 be accessible on the chain. This is the address for mainnet.
 export const multicallTwoAddress = "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696";
 
-export const DEFAULT_GAS_PRICE = toWeiSafe("300", 9);
-export const GAS_PRICE_BUFFER = toWeiSafe("1", 9);
+export const DEFAULT_GAS_PRICE = toWeiSafe(
+  process.env.REACT_APP_DEFAULT_GAS_PRICE || "400",
+  9
+);
+export const GAS_PRICE_BUFFER = toWeiSafe(
+  process.env.REACT_APP_GAS_PRICE_BUFFER || "50",
+  9
+);
 // Rounded up from a mainnet transaction sending eth gas limit
 export const ADD_LIQUIDITY_ETH_GAS = ethers.BigNumber.from(82796);


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

Gas estimate was sometimes wrong. This sets an interval to update gas price, as well as increasing price buffer to prevent gas estimate errors. This also puts these vars as envs so we can update without pr if need be.