### PR TITLE
Batch fixes two nov 7th

### DIFF
--- a/src/components/PoolForm/PoolForm.tsx
+++ b/src/components/PoolForm/PoolForm.tsx
@@ -50,6 +50,8 @@ interface Props {
   wrongNetwork?: boolean;
   // refetch balance
   refetchBalance: () => void;
+  defaultTab: string;
+  setDefaultTab: React.Dispatch<React.SetStateAction<string>>;
 }
 
 const PoolForm: FC<Props> = ({
@@ -69,6 +71,8 @@ const PoolForm: FC<Props> = ({
   balance,
   wrongNetwork,
   refetchBalance,
+  defaultTab,
+  setDefaultTab,
 }) => {
   const [inputAmount, setInputAmount] = useState("");
   const [removeAmount, setRemoveAmount] = useState(0);
@@ -178,7 +182,12 @@ const PoolForm: FC<Props> = ({
           <ROIItem>{numberFormatter(Number(apy)).replaceAll(",", "")}%</ROIItem>
         </ROIWrapper>
       </Info>
-      <Tabs>
+      <Tabs
+        defaultTab={defaultTab}
+        changeDefaultTab={(tab: string) => {
+          setDefaultTab(tab);
+        }}
+      >
         <TabContentWrapper data-label="Add">
           <AddLiquidityForm
             wrongNetwork={wrongNetwork}

--- a/src/components/PoolForm/RemoveLiquidityForm.styles.ts
+++ b/src/components/PoolForm/RemoveLiquidityForm.styles.ts
@@ -75,8 +75,8 @@ export const FeesBlock = styled.div`
 `;
 
 export const FeesPercent = styled.span`
-  color: var(--color-transparent-white);
-  font-weight: 700;
+  color: var(--color-white);
+  font-weight: 400;
 `;
 
 export const FeesBoldInfo = styled.div`
@@ -91,7 +91,7 @@ export const FeesInfo = styled.div`
 
 export const FeesValues = styled.div`
   text-align: right;
-  font-size: 14px;
+  font-size: ${14 / 16}rem;
   font-weight: 400;
   color: var(--color-transparent-white);
   &:first-of-type {

--- a/src/components/PoolForm/RemoveLiquidityForm.tsx
+++ b/src/components/PoolForm/RemoveLiquidityForm.tsx
@@ -151,7 +151,7 @@ const RemoveLiqudityForm: FC<Props> = ({
           <FeesBlockWrapper>
             <FeesBlock>
               <FeesBoldInfo>
-                Remove amount<FeesPercent>({removeAmount}%)</FeesPercent>
+                Remove amount <FeesPercent>({removeAmount}%)</FeesPercent>
               </FeesBoldInfo>
               <FeesInfo>Left in pool</FeesInfo>
             </FeesBlock>

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -4,14 +4,19 @@ import { TabList } from "./Tabs.styled";
 import { TabProps } from "./Tab";
 interface Props {
   children: Array<ReactElement<TabProps>>;
+  // If you need a default one on mount
+  defaultTab?: string;
+  // track default Tab if need be
+  changeDefaultTab?: (tab: string) => void;
 }
 
-const Tabs: FC<Props> = ({ children }) => {
+const Tabs: FC<Props> = ({ children, defaultTab, changeDefaultTab }) => {
   const [activeTab, setActiveTab] = useState<string>(
-    children[0].props["data-label"]
+    defaultTab ?? children[0].props["data-label"]
   );
 
   const onClickTabItem = (tab: string) => {
+    if (changeDefaultTab) changeDefaultTab(tab);
     setActiveTab(tab);
   };
 

--- a/src/onboard-override.css
+++ b/src/onboard-override.css
@@ -65,3 +65,36 @@
 .bn-onboard-custom.bn-onboard-icon-button div {
   margin-left: 8px;
 }
+
+.bn-notify-custom.bn-notify-notifications {
+  font-family: "Barlow";
+  border-radius: 5px !important;
+}
+
+.bn-notify-custom.bn-notify-notification-status-icon g circle,
+.bn-notify-custom.bn-notify-notification-status-icon g g {
+  stroke: var(--color-gray) !important;
+}
+
+.bn-notify-custom.bn-notify-notification-info {
+  font-family: "Barlow";
+}
+
+.bn-notify-custom.bn-notify-notification-info-message {
+  font-weight: 500;
+  color: var(--color-gray);
+}
+
+.bn-notify-custom.bn-notify-notification-close-icon {
+  opacity: 0.8;
+}
+
+.bn-notify-custom.bn-notify-notification-close-icon svg {
+  margin-top: 4px;
+  opacity: 0.8;
+}
+
+.bn-notify-custom.bn-notify-notification-close-icon svg g {
+  stroke: var(--color-gray);
+  margin-top: 4px;
+}

--- a/src/views/Pool.tsx
+++ b/src/views/Pool.tsx
@@ -25,7 +25,7 @@ const Pool: FC = () => {
   const [showSuccess, setShowSuccess] = useState(false);
   const [depositUrl, setDepositUrl] = useState("");
   const [loadingPoolState, setLoadingPoolState] = useState(false);
-
+  const [defaultTab, setDefaultTab] = useState("Add");
   const pool = useAppSelector((state) => state.pools.pools[token.bridgePool]);
   const connection = useAppSelector((state) => state.connection);
   const userPosition = useAppSelector((state) =>
@@ -138,6 +138,8 @@ const Pool: FC = () => {
               setDepositUrl={setDepositUrl}
               balance={balance}
               refetchBalance={refetchBalance}
+              defaultTab={defaultTab}
+              setDefaultTab={setDefaultTab}
             />
           ) : (
             <LoadingWrapper>


### PR DESCRIPTION
Following has been fixed:

1) Tabs widget has ability to set and change current default tab when it mounts:
https://app.shortcut.com/uma-project/story/2973/switching-currencies-in-pool-tab-should-not-reset-you-back-to-add-if-you-were-on-remove

2) Scroll to top when the deposit screen mounts:
https://app.shortcut.com/uma-project/story/2963/when-adding-removing-liquidity-and-getting-the-success-screen-my-screen-doesn-t-show-the-top-menu

3) Notify.js transaction modal has been updated
https://app.shortcut.com/uma-project/story/2965/transaction-modal-window-design

4) Updated fees percent span
https://app.shortcut.com/uma-project/story/3011/update-font-color-and-spacing-of-numbers-in-parenthesis-below