### PR TITLE
feat: swap banners appears under wallet

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -29,6 +29,7 @@ const Routes: FC<Props> = () => {
       chainId !== DEFAULT_TO_CHAIN_ID);
   return (
     <>
+      <Header />
       {wrongNetworkSend && location.pathname === "/" && (
         <SuperHeader>
           <div>
@@ -49,7 +50,6 @@ const Routes: FC<Props> = () => {
           </div>
         </SuperHeader>
       )}
-      <Header />
       <Switch>
         {!process.env.REACT_APP_HIDE_POOL ? (
           <Route exact path="/pool" component={Pool} />


### PR DESCRIPTION

<img width="2047" alt="Screen Shot 2021-11-07 at 12 51 42 PM" src="https://user-images.githubusercontent.com/12792146/140661567-e21c66fb-0285-440d-99d7-acd566af79a3.png">

https://app.shortcut.com/uma-project/story/3033/banner-should-appear-below-the-header-tabs-for-notifications-on-send-and-pool-tab

Signed-off-by: Tulun <jaykiraly@gmail.com>