### PR TITLE
fix: throw parsing error if send amount is negative

### DIFF
--- a/src/components/CoinSelection/CoinSelection.tsx
+++ b/src/components/CoinSelection/CoinSelection.tsx
@@ -76,6 +76,8 @@ const CoinSelection = () => {
     }
     try {
       const amount = parseUnits(value, selectedItem!.decimals);
+      // just throw an error if lt 0 and let the catch set the parsing error
+      if (amount.lt(0)) throw new Error();
       setAmount({ amount });
       if (error instanceof ParsingError) {
         setError(undefined);


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

https://app.shortcut.com/uma-project/story/2954/when-entering-a-negative-value-on-the-send-page-the-error-message-appears-when-you-type-negative-and-then-goes-away-when

Shows an error if u input less than 0 

![image](https://user-images.githubusercontent.com/4429761/140671231-675dee46-ca76-410c-a5db-f0874cbc7fbd.png)
