### PR TITLE
fix: add estimated wait to mainnet text on success page

### DIFF
--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -154,7 +154,9 @@ const SendAction: React.FC = () => {
               <div>Bridge Fee</div>
               <div>
                 {formatUnits(
-                  fees.instantRelayFee.total.add(fees.slowRelayFee.total).add(fees.lpFee.total),
+                  fees.instantRelayFee.total
+                    .add(fees.slowRelayFee.total)
+                    .add(fees.lpFee.total),
                   tokenInfo.decimals
                 )}{" "}
                 {tokenInfo.symbol}

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -154,7 +154,13 @@ export function useSend() {
       !error &&
       !fees.isAmountTooLow &&
       !fees.isLiquidityInsufficient &&
-      balance.sub(token === "0x0000000000000000000000000000000000000000" ? BigNumber.from(ethers.utils.parseEther(FEE_ESTIMATION)) : BigNumber.from("0")).gte(amount),
+      balance
+        .sub(
+          token === "0x0000000000000000000000000000000000000000"
+            ? BigNumber.from(ethers.utils.parseEther(FEE_ESTIMATION))
+            : BigNumber.from("0")
+        )
+        .gte(amount),
     [
       fromChain,
       block,

--- a/src/views/Confirmation/Confirmation.styles.ts
+++ b/src/views/Confirmation/Confirmation.styles.ts
@@ -18,7 +18,11 @@ export const Header = styled(Section)`
 export const Heading = styled(SectionTitle)`
   font-weight: 700;
   font-size: ${30 / 16}rem;
-  margin-bottom: 36px;
+`;
+
+export const SubHeading = styled(SectionTitle)`
+  font-weight: 100;
+  margin-bottom: 20px;
 `;
 
 export const SuccessIcon = styled.div`

--- a/src/views/Confirmation/Confirmation.tsx
+++ b/src/views/Confirmation/Confirmation.tsx
@@ -15,6 +15,7 @@ import {
   InfoSection,
   Header,
   Row,
+  SubHeading,
 } from "./Confirmation.styles";
 
 const Confirmation: React.FC = () => {
@@ -31,6 +32,7 @@ const Confirmation: React.FC = () => {
       <Wrapper>
         <Header>
           <Heading>Deposit succeeded</Heading>
+          <SubHeading>Your funds will arrive in ~2 minutes</SubHeading>
           <SuccessIcon>
             <Check strokeWidth={4} />
           </SuccessIcon>


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

https://app.shortcut.com/uma-project/story/2985/update-confirmation-page-showcasing-deposit-is-successful-and-funds-will-arrive-in-2-minutes

![image](https://user-images.githubusercontent.com/4429761/140674388-3d133876-a934-437a-b629-6dbe71b579fb.png)
