### PR TITLE
fix: reset change address box if cancelled

### DIFF
--- a/src/components/AddressSelection/AddressSelection.tsx
+++ b/src/components/AddressSelection/AddressSelection.tsx
@@ -34,6 +34,8 @@ const AddressSelection: React.FC = () => {
   }, [toAddress]);
 
   const toggle = () => {
+    // modal is closing, reset address to the current toAddress
+    if (open) setAddress(toAddress || address);
     setOpen((oldOpen) => !oldOpen);
   };
   const clearInput = () => {


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

https://app.shortcut.com/uma-project/story/2975/if-i-click-change-x-to-remove-the-current-address-cancel-and-then-open-up-the-change-dialog-again-the-address-box-will-still

resets the input box when user cancels change address