### PR TITLE
fix: allow parsing errors to show when not connected

### DIFF
--- a/src/components/CoinSelection/CoinSelection.tsx
+++ b/src/components/CoinSelection/CoinSelection.tsx
@@ -87,30 +87,33 @@ const CoinSelection = () => {
     }
   };
 
+  // checks for insufficient balance errors
   useEffect(() => {
-    if (balances && amount && inputAmount) {
-      const selectedIndex = tokenList.findIndex(
-        ({ address }) => address === token
-      );
-      const balance = balances[selectedIndex];
-      const isEth = tokenList[selectedIndex].symbol === "ETH";
-      if (
-        amount.lte(
-          isEth ? balance.sub(ethers.utils.parseEther(FEE_ESTIMATION)) : balance
-        )
-      ) {
-        // clear the previous error if it is not a parsing error
-        setError((oldError) => {
-          if (oldError instanceof ParsingError) {
-            return oldError;
-          }
-          return undefined;
-        });
-      } else {
-        setError(new Error("Insufficient balance."));
+    if (amount && inputAmount) {
+      // clear the previous error if it is not a parsing error
+      setError((oldError) => {
+        if (oldError instanceof ParsingError) {
+          return oldError;
+        }
+        return undefined;
+      });
+
+      if (balances) {
+        const selectedIndex = tokenList.findIndex(
+          ({ address }) => address === token
+        );
+        const balance = balances[selectedIndex];
+        const isEth = tokenList[selectedIndex].symbol === "ETH";
+        if (
+          amount.gt(
+            isEth
+              ? balance.sub(ethers.utils.parseEther(FEE_ESTIMATION))
+              : balance
+          )
+        ) {
+          setError(new Error("Insufficient balance."));
+        }
       }
-    } else {
-      setError(undefined);
     }
   }, [balances, amount, token, tokenList, inputAmount]);
 

--- a/src/views/About.tsx
+++ b/src/views/About.tsx
@@ -27,9 +27,9 @@ const About: FC = () => {
           <TextWrapper>
             <BulletHeader>Secure</BulletHeader>
             <BulletText>
-              Powered By UMA protocol. Transfers are secured by UMA's Optimistic Oracle,
-              which is audited by OpenZeppelin and trusted by top teams to
-              protect hundreds of millions of dollars in value.
+              Powered By UMA protocol. Transfers are secured by UMA's Optimistic
+              Oracle, which is audited by OpenZeppelin and trusted by top teams
+              to protect hundreds of millions of dollars in value.
             </BulletText>
           </TextWrapper>
         </Bullet>


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

Previously parsing errors would not show up on send page when typing invalid values while your wallet was not connected.  This changes how errors get cleared to maintain parsing errors if not connected. Previously all errors got cleared if not connected. 

![image](https://user-images.githubusercontent.com/4429761/140756838-ac45b01d-2931-4471-9b3d-b66516b3eed5.png)
