### PR TITLE
fix: allow parsing errors to show when not connected

### DIFF
--- a/src/views/About.tsx
+++ b/src/views/About.tsx
@@ -27,9 +27,9 @@ const About: FC = () => {
           <TextWrapper>
             <BulletHeader>Secure</BulletHeader>
             <BulletText>
-              Powered By UMA protocol. Transfers are secured by UMA's Optimistic Oracle,
-              which is audited by OpenZeppelin and trusted by top teams to
-              protect hundreds of millions of dollars in value.
+              Powered By UMA protocol. Transfers are secured by UMA's Optimistic
+              Oracle, which is audited by OpenZeppelin and trusted by top teams
+              to protect hundreds of millions of dollars in value.
             </BulletText>
           </TextWrapper>
         </Bullet>


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

Previously parsing errors would not show up on send page when typing invalid values while your wallet was not connected. This changes how errors get cleared to maintain parsing errors if not connected. Previously all errors got cleared if not connected.

![image](https://user-images.githubusercontent.com/4429761/140758932-962e023d-8e82-454d-8630-5815d590c531.png)
