### PR TITLE
fix: 0 balance account showing not enough funds for non numeric input

### DIFF
--- a/src/components/CoinSelection/CoinSelection.tsx
+++ b/src/components/CoinSelection/CoinSelection.tsx
@@ -100,7 +100,7 @@ const CoinSelection = () => {
         return undefined;
       });
 
-      if (balances) {
+      if (balances && amount.gt(0)) {
         const selectedIndex = tokenList.findIndex(
           ({ address }) => address === token
         );


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

To see bug: connect on the send tab with a wallet with 0 arb eth. then type characters in input box. it will say not enough balance. This only happens when you have 0 balance eth, and eth selected in dropdown. all other currencies dont have this problem. 

This just checks that the amount you have typed in is more than 0, before checking it against your balance. this seems to fix it. 