### PR TITLE
fix: add rate model for UMA

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -511,6 +511,12 @@ export const RATE_MODELS: Record<string, RateModel> = {
     R1: ethers.BigNumber.from("40000000000000000"),
     R2: ethers.BigNumber.from("600000000000000000"),
   },
+  UMA: {
+    UBar: ethers.BigNumber.from("500000000000000000"),
+    R0: ethers.BigNumber.from("0"),
+    R1: ethers.BigNumber.from("50000000000000000"),
+    R2: ethers.BigNumber.from("2000000000000000000"),
+  },
 };
 
 // this client requires multicall2 be accessible on the chain. This is the address for mainnet.


### PR DESCRIPTION
Rate model was missing for UMA, making it impossible to do transfers.

Rate model was pulled from the UMIP here: https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-136.md.

Fixes #40.