### PR TITLE
feat(across): add info modal and minor fixes

### DIFF
--- a/src/assets/border.svg
+++ b/src/assets/border.svg
@@ -1,0 +1,27 @@
+<svg width="490" height="10" viewBox="0 0 490 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<circle cx="5" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="25" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="45" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="65" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="85" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="105" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="125" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="145" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="165" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="185" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="205" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="225" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="245" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="265" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="285" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="305" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="325" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="345" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="365" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="385" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="405" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="425" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="445" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="465" cy="5" r="5" fill="#2D2E33" />
+	<circle cx="485" cy="5" r="5" fill="#2D2E33" />
+</svg>

--- a/src/components/InformationDialog/InformationDialog.tsx
+++ b/src/components/InformationDialog/InformationDialog.tsx
@@ -50,7 +50,7 @@ const InformationDialog: React.FC<Props> = ({ isOpen, onClose }) => {
         <li>
           Click{" "}
           <Link
-            href="https://app.gitbook.com/o/-MlBqw0sVAJZO0pl5jGc/s/-MlBr3oaDzSVL5ybJHcV/how-does-across-work-1/architecture-process-walkthrough"
+            href="https://across.gitbook.io/bridge/how-does-across-work-1/architecture-process-walkthrough"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/src/components/InformationDialog/InformationDialog.tsx
+++ b/src/components/InformationDialog/InformationDialog.tsx
@@ -1,0 +1,122 @@
+import React from "react";
+import styled from "@emotion/styled";
+import Dialog from "../Dialog";
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+const InformationDialog: React.FC<Props> = ({ isOpen, onClose }) => {
+  return (
+    <Dialog isOpen={isOpen} onClose={onClose}>
+      <Title>Information</Title>
+      <Info>
+        <ArticleTitle>Time to Ethereum Mainnet</ArticleTitle>
+        <Text>
+          The estimated amount of time expected to receive your funds on
+          Ethereum Mainnet. If you do not receive your funds within the
+          estimated amount of time, please visit the ‘across-support’ channel
+          within the{" "}
+          <Link
+            href="https://discord.gg/across"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Across Discord.
+          </Link>
+        </Text>
+      </Info>
+      <Info>
+        <ArticleTitle>Bridge Fee</ArticleTitle>
+        <Text>
+          Assets are transferred near instantly by utilizing funds from a
+          liquidity pool. The bridge fee is comprised of a liquidity provider
+          fee that rewards liquidity providers on Across.
+        </Text>
+      </Info>
+      <Info>
+        <ArticleTitle>Gas Fee</ArticleTitle>
+        <Text>
+          Across sends funds by default via an instant relay. If an instant
+          relay is unavailable, a slow relay will occur. Instant and slow
+          relayers charge a fee for performing the relay. These fees are
+          dependent on Ethereum Gas fees. View here to learn more about Ethereum
+          gas fees.
+        </Text>
+      </Info>
+
+      <List>
+        <li>
+          Click{" "}
+          <Link
+            href="https://app.gitbook.com/o/-MlBqw0sVAJZO0pl5jGc/s/-MlBr3oaDzSVL5ybJHcV/how-does-across-work-1/architecture-process-walkthrough"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            here
+          </Link>{" "}
+          to learn more about instant and slow relayers.
+        </li>
+        <li>
+          Click{" "}
+          <Link
+            href="https://across.gitbook.io/bridge/how-does-across-work-1/fees"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            here
+          </Link>{" "}
+          or more information on Across fees.
+        </li>
+        <li>
+          Click{" "}
+          <Link
+            href="https://ethereum.org/en/developers/docs/gas/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            here
+          </Link>{" "}
+          to learn more about Ethereum gas fees.
+        </li>
+      </List>
+    </Dialog>
+  );
+};
+export default InformationDialog;
+
+const Title = styled.h1`
+  font-size: ${20 / 16}rem;
+  font-weight: bold;
+  margin-bottom: 25px;
+`;
+
+const Info = styled.article`
+  margin-bottom: 20px;
+  font-size: ${14 / 16}rem;
+`;
+
+const ArticleTitle = styled.h2`
+  font-weight: bold;
+  margin-bottom: 8px;
+`;
+
+const Text = styled.p`
+  max-width: 65ch;
+`;
+
+const Link = styled.a`
+  color: var(--color-secondary);
+  text-decoration: none;
+  transform: opacity 100ms linear;
+
+  &:hover {
+    text-decoration: revert;
+  }
+`;
+
+const List = styled.ul`
+  list-style: inside;
+  font-size: ${14 / 16}rem;
+`;

--- a/src/components/InformationDialog/index.ts
+++ b/src/components/InformationDialog/index.ts
@@ -1,0 +1,2 @@
+import InformationDialog from "./InformationDialog";
+export default InformationDialog;

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -61,6 +61,8 @@ const Layout: React.FC = ({ children }) => (
 export default Layout;
 
 const Footer = styled.footer`
+  position: sticky;
+  bottom: 0;
   padding: 0 15px 15px;
   align-self: self-end;
   &:last-of-type {

--- a/src/components/Section/Section.tsx
+++ b/src/components/Section/Section.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import AccentSectionBorder from "assets/border.svg";
 
 export const Section = styled.section`
   color: var(--color-white);
@@ -10,9 +11,9 @@ export const SectionTitle = styled.h3`
 `;
 export const AccentSection = styled.section`
   padding: 0 30px;
-  background-image: linear-gradient(
-    var(--color-primary-dark),
-    var(--color-gray)
-  );
+  background-image: url(${AccentSectionBorder}),
+    linear-gradient(var(--color-primary-dark), var(--color-gray));
+  background-repeat: no-repeat, repeat;
+  background-position: top -4px center, 0% 0%;
   border: 1px solid var(--color-gray);
 `;

--- a/src/components/SendAction/SendAction.styles.ts
+++ b/src/components/SendAction/SendAction.styles.ts
@@ -8,15 +8,25 @@ export const AccentSection = styled(UnstyledAccentSection)`
 
 export const InfoIcon = styled(UnstyledInfoIcon)`
   position: absolute;
-  top: 0;
-  right: 0;
+  top: 30px;
+  right: 0px;
+  cursor: pointer;
+  color: var(--color-gray);
+  fill: currentColor;
+  & > line {
+    stroke: var(--color-white-transparent);
+    transition: stroke 100ms linear;
+  }
+  &:hover > line {
+    stroke: var(--color-white);
+  }
 `;
 
 export const Wrapper = styled.div`
   position: relative;
   display: flex;
   flex-direction: column;
-  padding: 40px 0;
+  padding: 65px 0;
 `;
 
 export const Info = styled.div`

--- a/src/components/SendAction/SendAction.styles.ts
+++ b/src/components/SendAction/SendAction.styles.ts
@@ -1,6 +1,19 @@
 import styled from "@emotion/styled";
+import { Info as UnstyledInfoIcon } from "react-feather";
+import { AccentSection as UnstyledAccentSection } from "../Section";
+
+export const AccentSection = styled(UnstyledAccentSection)`
+  position: relative;
+`;
+
+export const InfoIcon = styled(UnstyledInfoIcon)`
+  position: absolute;
+  top: 0;
+  right: 0;
+`;
 
 export const Wrapper = styled.div`
+  position: relative;
   display: flex;
   flex-direction: column;
   padding: 40px 0;

--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -18,8 +18,8 @@ import {
   formatUnits,
   receiveAmount,
 } from "utils";
-import { PrimaryButton, AccentSection } from "components";
-import { Wrapper, Info } from "./SendAction.styles";
+import { PrimaryButton } from "components";
+import { Wrapper, Info, AccentSection, InfoIcon } from "./SendAction.styles";
 import api from "state/chainApi";
 
 const CONFIRMATIONS = 1;
@@ -175,6 +175,7 @@ const SendAction: React.FC = () => {
         <PrimaryButton onClick={handleClick} disabled={buttonDisabled}>
           {buttonMsg()}
         </PrimaryButton>
+        <InfoIcon />
       </Wrapper>
     </AccentSection>
   );

--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -18,9 +18,10 @@ import {
   formatUnits,
   receiveAmount,
 } from "utils";
-import { PrimaryButton } from "components";
+import { PrimaryButton } from "../Buttons";
 import { Wrapper, Info, AccentSection, InfoIcon } from "./SendAction.styles";
 import api from "state/chainApi";
+import InformationDialog from "components/InformationDialog";
 
 const CONFIRMATIONS = 1;
 const MAX_APPROVAL_AMOUNT = ethers.constants.MaxUint256;
@@ -40,6 +41,8 @@ const SendAction: React.FC = () => {
 
   const { block } = useBlocks(toChain);
 
+  const [isInfoModalOpen, setOpenInfoModal] = useState(false);
+  const toggleInfoModal = () => setOpenInfoModal((oldOpen) => !oldOpen);
   const [isSendPending, setSendPending] = useState(false);
   const [isApprovalPending, setApprovalPending] = useState(false);
   const { addTransaction } = useTransactions();
@@ -169,14 +172,15 @@ const SendAction: React.FC = () => {
                 {tokenInfo.symbol}
               </div>
             </Info>
+            <InfoIcon aria-label="info dialog" onClick={toggleInfoModal} />
           </>
         )}
 
         <PrimaryButton onClick={handleClick} disabled={buttonDisabled}>
           {buttonMsg()}
         </PrimaryButton>
-        <InfoIcon />
       </Wrapper>
+      <InformationDialog isOpen={isInfoModalOpen} onClose={toggleInfoModal} />
     </AccentSection>
   );
 };


### PR DESCRIPTION
**Motivation**
This PR adds the information modal and is bundled with 2 additional small UI improvements, it makes the footers on the Send and Pool tab sticky again and it add the "ticket" border to the accent section like in the designs

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested