### PR TITLE
fix: fix fees earned to show correct value

### DIFF
--- a/src/components/PoolForm/PoolForm.tsx
+++ b/src/components/PoolForm/PoolForm.tsx
@@ -158,7 +158,7 @@ const PoolForm: FC<Props> = ({
           <PositionBlock>
             <PositionBlockItem>Fees earned</PositionBlockItem>
             <PositionBlockItem>
-              {Number(formatUnits(feesEarned, decimals)) < 0
+              {Number(formatUnits(feesEarned, decimals)) > 0
                 ? formatUnits(feesEarned, decimals)
                 : "0.0000"}{" "}
               {symbol}


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

fix inverted comparator to prevent showing negative fees

![image](https://user-images.githubusercontent.com/4429761/141033784-5765c2bc-7505-4d06-83f3-66780d06b458.png)
