### PR TITLE
fix(across): fix etherscan link

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -285,10 +285,8 @@ export const CHAINS: Record<ChainId, ChainInfo> = {
     name: "Ethereum Mainnet",
     chainId: ChainId.MAINNET,
     logoURI: ethereumLogo,
-    explorerUrl: "https://etherscan.io/",
-    constructExplorerLink: defaultConstructExplorerLink(
-      "https://etherscan.io/"
-    ),
+    explorerUrl: "https://etherscan.io",
+    constructExplorerLink: defaultConstructExplorerLink("https://etherscan.io"),
     nativeCurrency: {
       name: "Ether",
       symbol: "ETH",
@@ -328,9 +326,9 @@ export const CHAINS: Record<ChainId, ChainInfo> = {
     chainId: ChainId.OPTIMISM,
     logoURI: optimismLogo,
     rpcUrl: "https://mainnet.optimism.io",
-    explorerUrl: "https://optimistic.etherscan.io/",
+    explorerUrl: "https://optimistic.etherscan.io",
     constructExplorerLink: defaultConstructExplorerLink(
-      "https://optimistic.etherscan.io/"
+      "https://optimistic.etherscan.io"
     ),
     nativeCurrency: {
       name: "Ether",

--- a/src/views/Confirmation/Confirmation.tsx
+++ b/src/views/Confirmation/Confirmation.tsx
@@ -107,7 +107,7 @@ const Confirmation: React.FC = () => {
                 <div>
                   <SecondaryLink
                     href={`${CHAINS[deposit.toChain].explorerUrl}/address/${
-                      deposit.to
+                      deposit.toAddress
                     }`}
                     target="_blank"
                     rel="noopener noreferrer"


### PR DESCRIPTION
**Motivation**
This PR fixes a small bug with etherscan links on the confirmation screen. Also some `blockExplorerUrls` had a final `/` and some didn't, so I normalized them all to not have a final /

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested