### PR TITLE
fix(across): center-align poweredByUMA

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -65,13 +65,10 @@ const Footer = styled.footer`
   bottom: 0;
   padding: 0 15px 15px;
   align-self: self-end;
-  &:last-of-type {
-    justify-self: self-end;
-  }
+  justify-self: center;
 
   &:first-of-type {
     display: flex;
-    justify-self: center;
     padding-bottom: 25px;
     & svg {
       width: 25px;


### PR DESCRIPTION
This PR center aligns the "Powered By UMA" link as requested in https://app.shortcut.com/uma-project/story/3335/align-powered-by-uma-and-the-rest-of-the-footers 

Before:
<img width="2549" alt="CleanShot 2021-12-02 at 16 10 36@2x" src="https://user-images.githubusercontent.com/29527327/144448778-e987cad8-ad05-4ee7-b255-e265a1d3de4a.png">

After:
![image](https://user-images.githubusercontent.com/29527327/144448710-26c87e64-384a-42d0-999e-60f914ddea38.png)
