### PR TITLE
Qa updates dropdown

### DIFF
--- a/src/components/AddressSelection/AddressSelection.styles.ts
+++ b/src/components/AddressSelection/AddressSelection.styles.ts
@@ -127,6 +127,7 @@ export const Menu = styled.ul<IMenuProps>`
   z-index: 10000;
   width: 95%;
   margin: 0 auto;
+  box-shadow: inset 0 8px 8% rgba(45, 46, 51, 0.2);
 `;
 
 export const Item = styled.li`
@@ -208,4 +209,7 @@ export const ToggleChainName = styled.div`
 export const ItemWarning = styled(Item)`
   background-color: #6cf9d8;
   color: #000000;
+  &:hover {
+    background-color: #6cf9d8;
+  }
 `;

--- a/src/components/AddressSelection/AddressSelection.styles.ts
+++ b/src/components/AddressSelection/AddressSelection.styles.ts
@@ -211,5 +211,6 @@ export const ItemWarning = styled(Item)`
   color: #000000;
   &:hover {
     background-color: #6cf9d8;
+    cursor: not-allowed;
   }
 `;

--- a/src/components/AddressSelection/AddressSelection.tsx
+++ b/src/components/AddressSelection/AddressSelection.tsx
@@ -153,7 +153,7 @@ const AddressSelection: React.FC = () => {
                         <Logo src={t.logoURI} alt={t.name} />
                         <div>{t.name}</div>
                         <span className="layer-type">
-                          {t.name !== "Ether" ? "L2" : "L1"}
+                          {index !== CHAINS_SELECTION.length - 1 ? "L2" : "L1"}
                         </span>
                       </Item>
                     );

--- a/src/components/ChainSelection/ChainSelection.styles.tsx
+++ b/src/components/ChainSelection/ChainSelection.styles.tsx
@@ -51,6 +51,7 @@ export const Menu = styled.ul<IMenuProps>`
   right: 0;
   padding-top: 10px;
   transform: translateY(100%);
+  box-shadow: inset 0 8px 8% rgba(45, 46, 51, 0.2);
   list-style: none;
   display: ${(props) => (props.isOpen ? "flex" : "none")};
   flex-direction: column;

--- a/src/components/ChainSelection/ChainSelection.tsx
+++ b/src/components/ChainSelection/ChainSelection.tsx
@@ -20,6 +20,9 @@ import { CHAINS_SELECTION } from "utils/constants";
 import { actions } from "state/send";
 import { useAppDispatch, useAppSelector } from "state/hooks";
 
+// Remove eth from this list.
+const filteredChains = CHAINS_SELECTION.slice(0, CHAINS_SELECTION.length - 1);
+
 const ChainSelection: React.FC = () => {
   const { init } = onboard;
   const { isConnected, provider, chainId, error } = useConnection();
@@ -55,7 +58,7 @@ const ChainSelection: React.FC = () => {
     getItemProps,
     getMenuProps,
   } = useSelect({
-    items: CHAINS_SELECTION,
+    items: filteredChains,
     defaultSelectedItem: sendState.currentlySelectedFromChain,
     selectedItem: sendState.currentlySelectedFromChain,
     onSelectedItemChange: ({ selectedItem }) => {
@@ -97,7 +100,7 @@ const ChainSelection: React.FC = () => {
           </RoundBox>
           <Menu isOpen={isOpen} {...getMenuProps()}>
             {isOpen &&
-              CHAINS_SELECTION.map((t, index) => {
+              filteredChains.map((t, index) => {
                 return (
                   <Item
                     className={

--- a/src/components/ChainSelection/ChainSelection.tsx
+++ b/src/components/ChainSelection/ChainSelection.tsx
@@ -73,7 +73,11 @@ const ChainSelection: React.FC = () => {
           selectedItem.chainId !== ChainId.MAINNET &&
           sendState.currentlySelectedToChain.chainId !== ChainId.MAINNET
         ) {
-          dispatch(actions.updateSelectedToChain(CHAINS_SELECTION[CHAINS_SELECTION.length - 1]));
+          dispatch(
+            actions.updateSelectedToChain(
+              CHAINS_SELECTION[CHAINS_SELECTION.length - 1]
+            )
+          );
         }
       }
     },
@@ -107,7 +111,7 @@ const ChainSelection: React.FC = () => {
                     <Logo src={t.logoURI} alt={t.name} />
                     <div>{t.name}</div>
                     <span className="layer-type">
-                      {t.name !== "Ether" ? "L2" : "L1"}
+                      {index !== CHAINS_SELECTION.length - 1 ? "L2" : "L1"}
                     </span>
                   </Item>
                 );

--- a/src/components/CoinSelection/CoinSelection.styles.ts
+++ b/src/components/CoinSelection/CoinSelection.styles.ts
@@ -58,6 +58,7 @@ export const Menu = styled.ul`
   right: 0;
   padding-top: 10px;
   transform: translateY(100%);
+  box-shadow: inset 0 8px 8% rgba(45, 46, 51, 0.2);
   list-style: none;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Following fixes to dropdown:

L1 not L2 for ETH.

https://app.shortcut.com/uma-project/story/3358/ethereum-should-be-l1-not-l2-in-dropdown
<img width="567" alt="Screen Shot 2021-12-02 at 4 49 06 PM" src="https://user-images.githubusercontent.com/12792146/144525932-faae52bd-a6bc-43a7-a5e6-4d1feb765b42.png">

ETH filtered out of from.

https://app.shortcut.com/uma-project/story/3375/remove-eth-from-the-from-dropdown-since-this-functionality-will-not-be-ready-until-post-launch-of-optimism-and-boba
<img width="646" alt="Screen Shot 2021-12-02 at 4 50 03 PM" src="https://user-images.githubusercontent.com/12792146/144526023-3e9e49c7-a7f9-41e4-a202-4591463bd3ae.png">

Hover effect removed from "L1 to L2..."
https://app.shortcut.com/uma-project/story/3360/remove-hover-effect-on-transfers-between-l2-area-in-second-dropdown

Box shadow added.
  box-shadow: inset 0 8px 8% rgba(45, 46, 51, 0.2);
<img width="477" alt="Screen Shot 2021-12-02 at 4 53 22 PM" src="https://user-images.githubusercontent.com/12792146/144526273-77587eea-59e9-48cf-9a73-39279935b975.png">

https://app.shortcut.com/uma-project/story/3363/add-drop-shadow-on-dropdowns
