### PR TITLE
fix(across): minor css fixes

### DIFF
--- a/src/components/ChainSelection/ChainSelection.styles.tsx
+++ b/src/components/ChainSelection/ChainSelection.styles.tsx
@@ -5,6 +5,7 @@ import { RoundBox as UnstyledBox } from "../Box";
 export const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
+  padding-top: 20px;
 `;
 
 export const RoundBox = styled(UnstyledBox)`

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -13,7 +13,7 @@ import {
 } from "./Header.styles";
 
 const LINKS = [
-  { href: "/", name: "Send" },
+  { href: "/", name: "Bridge" },
   { href: "/pool", name: "Pool" },
   { href: "/about", name: "About" },
 ];

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -8,11 +8,11 @@ import { ReactComponent as TwitterLogo } from "assets/icon-twitter.svg";
 const NAV_LINKS = [
   {
     name: "FAQ",
-    url: "https://across.gitbook.io/bridge/faq",
+    url: "https://docs.across.to/bridge/faq",
   },
   {
     name: "Docs",
-    url: "https://across.gitbook.io/bridge/",
+    url: " https://docs.across.to/bridge/",
   },
 ];
 const DISCORD_LINK = {

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -12,7 +12,7 @@ const NAV_LINKS = [
   },
   {
     name: "Docs",
-    url: " https://docs.across.to/bridge/",
+    url: "https://docs.across.to/bridge/",
   },
 ];
 const DISCORD_LINK = {

--- a/src/components/PoolSelection/PoolSelection.styles.ts
+++ b/src/components/PoolSelection/PoolSelection.styles.ts
@@ -9,6 +9,7 @@ export const Wrapper = styled(Section)`
   border-bottom: none;
   display: flex;
   flex-direction: column;
+  padding-top: 20px;
 `;
 export const RoundBox = styled(UnstyledBox)`
   --color: var(--color-white);

--- a/src/views/About.tsx
+++ b/src/views/About.tsx
@@ -10,11 +10,11 @@ import { COLORS } from "utils";
 const NAV_LINKS = [
   {
     name: "FAQ",
-    url: "https://across.gitbook.io/bridge/faq",
+    url: "https://docs.across.to/bridge/faq",
   },
   {
     name: "Docs",
-    url: "https://across.gitbook.io/bridge/",
+    url: "https://docs.across.to/bridge/",
   },
 ];
 const DISCORD_LINK = {


### PR DESCRIPTION
This PR fixes
- https://app.shortcut.com/uma-project/story/3164/update-the-name-of-the-send-tab-to-bridge
- https://app.shortcut.com/uma-project/story/2970/standardize-35px-spacing-on-both-tabs
- https://app.shortcut.com/uma-project/story/3329/update-doc-site-link-in-footer-to-docs-across-to