### PR TITLE
fix: use from chain block.timestamp for lp fee lookups

### DIFF
--- a/src/components/CoinSelection/CoinSelection.tsx
+++ b/src/components/CoinSelection/CoinSelection.tsx
@@ -156,7 +156,7 @@ const CoinSelection = () => {
     {
       amount,
       tokenSymbol: selectedItem!.symbol,
-      blockNumber: block?.blockNumber ?? 0,
+      blockTime: block?.timestamp,
     },
     { skip: amount.lte(0) || !block || !selectedItem?.symbol }
   );

--- a/src/components/CoinSelection/CoinSelection.tsx
+++ b/src/components/CoinSelection/CoinSelection.tsx
@@ -156,9 +156,9 @@ const CoinSelection = () => {
     {
       amount,
       tokenSymbol: selectedItem!.symbol,
-      blockTime: block?.timestamp,
+      blockTime: block?.timestamp!,
     },
-    { skip: amount.lte(0) || !block || !selectedItem?.symbol }
+    { skip: amount.lte(0) || !block?.timestamp || !selectedItem?.symbol }
   );
 
   const errorMsg = error

--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -32,7 +32,7 @@ const SendAction: React.FC = () => {
   const { account } = useConnection();
   const sendState = useAppSelector((state) => state.send);
 
-  const { block } = useBlocks(sendState.currentlySelectedToChain.chainId);
+  const { block } = useBlocks(sendState.currentlySelectedFromChain.chainId);
 
   const [isInfoModalOpen, setOpenInfoModal] = useState(false);
   const toggleInfoModal = () => setOpenInfoModal((oldOpen) => !oldOpen);
@@ -53,7 +53,7 @@ const SendAction: React.FC = () => {
     {
       amount,
       tokenSymbol: tokenInfo ? tokenInfo.symbol : "",
-      blockNumber: block?.blockNumber ?? 0,
+      blockTime: block?.timestamp,
     },
     { skip: !tokenInfo || !block || !amount.gt(0) }
   );

--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -53,9 +53,9 @@ const SendAction: React.FC = () => {
     {
       amount,
       tokenSymbol: tokenInfo ? tokenInfo.symbol : "",
-      blockTime: block?.timestamp,
+      blockTime: block?.timestamp!,
     },
-    { skip: !tokenInfo || !block || !amount.gt(0) }
+    { skip: !tokenInfo || !block?.timestamp || !amount.gt(0) }
   );
 
   const depositBox = getDepositBox(

--- a/src/state/chainApi.ts
+++ b/src/state/chainApi.ts
@@ -22,7 +22,7 @@ type AllowanceQueryArgs = {
 type BridgeFeesQueryArgs = {
   amount: ethers.BigNumber;
   tokenSymbol: string;
-  blockTime?: number;
+  blockTime: number;
 };
 
 type BridgeFeesQueryResult = BridgeFees & {

--- a/src/state/chainApi.ts
+++ b/src/state/chainApi.ts
@@ -22,7 +22,7 @@ type AllowanceQueryArgs = {
 type BridgeFeesQueryArgs = {
   amount: ethers.BigNumber;
   tokenSymbol: string;
-  blockNumber: number;
+  blockTime?: number;
 };
 
 type BridgeFeesQueryResult = BridgeFees & {
@@ -102,14 +102,15 @@ const api = createApi({
     }),
     bridgeFees: build.query<BridgeFeesQueryResult, BridgeFeesQueryArgs>({
       // We want to re-run the fee query on each block change
-      queryFn: async ({ amount, tokenSymbol, blockNumber }) => {
+      queryFn: async ({ amount, tokenSymbol, blockTime }) => {
         try {
           const { instantRelayFee, slowRelayFee, isAmountTooLow } =
             await getRelayFees(tokenSymbol, amount);
 
           const { isLiquidityInsufficient, ...lpFee } = await getLpFee(
             tokenSymbol,
-            amount
+            amount,
+            blockTime
           );
 
           return {

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -118,7 +118,7 @@ export function useSend() {
     tokenAddress: token,
   });
   const balance = BigNumber.from(balanceStr);
-  const { block } = useBlocks(currentlySelectedToChain.chainId);
+  const { block } = useBlocks(currentlySelectedFromChain.chainId);
 
   const depositBox = getDepositBox(currentlySelectedFromChain.chainId);
   const { data: allowance } = useAllowance(
@@ -144,7 +144,7 @@ export function useSend() {
     {
       amount,
       tokenSymbol,
-      blockNumber: block?.blockNumber ?? 0,
+      blockTime: block?.timestamp,
     },
     { skip: tokenSymbol === "" || amount.lte(0) || !block }
   );
@@ -202,12 +202,6 @@ export function useSend() {
         : token;
       const { instantRelayFee, slowRelayFee } = fees;
       let timestamp = block.timestamp;
-      // MAJOR HACK FOR OPTIMISM TESTING. DO NOT MERGE INTO PRODUCTION
-      // This is due to a bug in Optimism currently being 10-12 minutes behind Eth Mainnet.
-      if (currentlySelectedFromChain.chainId === ChainId.OPTIMISM) {
-        const TEN_MINUTES_IN_SECONDS = 600;
-        timestamp = block.timestamp - TEN_MINUTES_IN_SECONDS;
-      }
 
       const tx = await depositBox.deposit(
         toAddress,

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -144,9 +144,9 @@ export function useSend() {
     {
       amount,
       tokenSymbol,
-      blockTime: block?.timestamp,
+      blockTime: block?.timestamp!,
     },
-    { skip: tokenSymbol === "" || amount.lte(0) || !block }
+    { skip: tokenSymbol === "" || amount.lte(0) || !block?.timestamp }
   );
 
   const canSend = useMemo(

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -538,40 +538,6 @@ export function onboardBaseConfig(): Initialization {
   };
 }
 
-type RateModel = {
-  UBar: ethers.BigNumber;
-  R0: ethers.BigNumber;
-  R1: ethers.BigNumber;
-  R2: ethers.BigNumber;
-};
-export const RATE_MODELS: Record<string, RateModel> = {
-  // this should be the same as weth?
-  ETH: {
-    UBar: ethers.BigNumber.from("650000000000000000"),
-    R0: ethers.BigNumber.from("0"),
-    R1: ethers.BigNumber.from("80000000000000000"),
-    R2: ethers.BigNumber.from("1000000000000000000"),
-  },
-  WETH: {
-    UBar: ethers.BigNumber.from("650000000000000000"),
-    R0: ethers.BigNumber.from("0"),
-    R1: ethers.BigNumber.from("80000000000000000"),
-    R2: ethers.BigNumber.from("1000000000000000000"),
-  },
-  USDC: {
-    UBar: ethers.BigNumber.from("800000000000000000"),
-    R0: ethers.BigNumber.from("0"),
-    R1: ethers.BigNumber.from("40000000000000000"),
-    R2: ethers.BigNumber.from("600000000000000000"),
-  },
-  UMA: {
-    UBar: ethers.BigNumber.from("500000000000000000"),
-    R0: ethers.BigNumber.from("0"),
-    R1: ethers.BigNumber.from("50000000000000000"),
-    R2: ethers.BigNumber.from("2000000000000000000"),
-  },
-};
-
 // this client requires multicall2 be accessible on the chain. This is the address for mainnet.
 export const multicallTwoAddress = "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696";
 export interface IChainSelection {


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

This uses the sdk to help calculate fees based on the "from chain" current timestamp. Anywhere the fees are queried, blocks are taken from the selected "from" chain rather than the "to" chain (mainnet).  This timestamp is passed into the lp fee calculator.