### PR TITLE
fix: fix token lookup from current from selection

### DIFF
--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -138,7 +138,9 @@ export function useSend() {
     isConnected && currentlySelectedFromChain.chainId !== chainId;
 
   const tokenSymbol =
-    TOKENS_LIST[fromChain].find((t) => t.address === token)?.symbol ?? "";
+    TOKENS_LIST[currentlySelectedFromChain.chainId].find(
+      (t) => t.address === token
+    )?.symbol ?? "";
 
   const { data: fees } = useBridgeFees(
     {
@@ -185,6 +187,7 @@ export function useSend() {
       balance,
     ]
   );
+
   const send = useCallback(async () => {
     if (!signer || !canSend || !fees || !toAddress || !block) {
       return {};


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

This was caused by `fromChain` not being synced with the UI. If you switch the ui `from` to arbitrum and back, this fixes the issue without code changes, but this fix does the token lookup based on `currentlySelectedFromChain` which is always synced to the ui afaik