### PR TITLE
fix(across): change show success type and message

### DIFF
--- a/src/components/PoolForm/AddLiquidityForm.tsx
+++ b/src/components/PoolForm/AddLiquidityForm.tsx
@@ -34,7 +34,7 @@ interface Props {
   decimals: number;
   symbol: string;
   tokenAddress: string;
-  setShowSuccess: React.Dispatch<React.SetStateAction<ShowSuccess>>;
+  setShowSuccess: React.Dispatch<React.SetStateAction<ShowSuccess | undefined>>;
   setDepositUrl: React.Dispatch<React.SetStateAction<string>>;
   balance: string;
   setAmount: React.Dispatch<React.SetStateAction<string>>;
@@ -150,7 +150,7 @@ const AddLiquidityForm: FC<Props> = ({
           emitter.on("all", addEtherscan);
           emitter.on("txConfirmed", (tx) => {
             if (transaction.hash) notify.unsubscribe(transaction.hash);
-            setShowSuccess({ type: "deposit", value: true });
+            setShowSuccess("deposit");
             setTxSubmitted(false);
             const url = `https://etherscan.io/tx/${transaction.hash}`;
             setDepositUrl(url);

--- a/src/components/PoolForm/AddLiquidityForm.tsx
+++ b/src/components/PoolForm/AddLiquidityForm.tsx
@@ -20,6 +20,7 @@ import { addEtherscan } from "utils/notify";
 import BouncingDotsLoader from "components/BouncingDotsLoader";
 import { DEFAULT_TO_CHAIN_ID, CHAINS, switchChain } from "utils";
 import api from "state/chainApi";
+import type { ShowSuccess } from "views/Pool";
 
 // max uint value is 2^256 - 1
 const MAX_UINT_VAL = ethers.constants.MaxUint256;
@@ -33,7 +34,7 @@ interface Props {
   decimals: number;
   symbol: string;
   tokenAddress: string;
-  setShowSuccess: React.Dispatch<React.SetStateAction<boolean>>;
+  setShowSuccess: React.Dispatch<React.SetStateAction<ShowSuccess>>;
   setDepositUrl: React.Dispatch<React.SetStateAction<string>>;
   balance: string;
   setAmount: React.Dispatch<React.SetStateAction<string>>;
@@ -149,7 +150,7 @@ const AddLiquidityForm: FC<Props> = ({
           emitter.on("all", addEtherscan);
           emitter.on("txConfirmed", (tx) => {
             if (transaction.hash) notify.unsubscribe(transaction.hash);
-            setShowSuccess(true);
+            setShowSuccess({ type: "deposit", value: true });
             setTxSubmitted(false);
             const url = `https://etherscan.io/tx/${transaction.hash}`;
             setDepositUrl(url);

--- a/src/components/PoolForm/DepositSuccess.tsx
+++ b/src/components/PoolForm/DepositSuccess.tsx
@@ -6,21 +6,22 @@ import type { ShowSuccess } from "views/Pool";
 
 interface Props {
   depositUrl: string;
-  setShowSuccess: React.Dispatch<React.SetStateAction<ShowSuccess>>;
+  setShowSuccess: React.Dispatch<React.SetStateAction<ShowSuccess | undefined>>;
   setDepositUrl: React.Dispatch<React.SetStateAction<string>>;
-  isRemoval?: boolean;
+  showSuccess: ShowSuccess;
 }
 const DepositSuccess: FC<Props> = ({
   depositUrl,
   setShowSuccess,
   setDepositUrl,
-  isRemoval = false,
+  showSuccess,
 }) => {
   // Make sure we scroll to top when deposit screen mounts
   useEffect(() => {
     window.scroll(0, 0);
   }, []);
-  const message = isRemoval ? "Withdrawal succeeded" : "Deposit succeeded";
+  const message =
+    showSuccess === "withdraw" ? "Withdrawal succeeded" : "Deposit succeeded";
   return (
     <div>
       <DepositTopWrapper>
@@ -37,7 +38,7 @@ const DepositSuccess: FC<Props> = ({
         </EtherscanUrl>
         <DepositButton
           onClick={() => {
-            setShowSuccess((oldShow) => ({ ...oldShow, value: false }));
+            setShowSuccess(undefined);
             setDepositUrl("");
           }}
         >

--- a/src/components/PoolForm/DepositSuccess.tsx
+++ b/src/components/PoolForm/DepositSuccess.tsx
@@ -2,25 +2,29 @@ import { FC, useEffect } from "react";
 import styled from "@emotion/styled";
 import { PrimaryButton } from "../Buttons";
 import { Check, ArrowUpRight } from "react-feather";
+import type { ShowSuccess } from "views/Pool";
 
 interface Props {
   depositUrl: string;
-  setShowSuccess: React.Dispatch<React.SetStateAction<boolean>>;
+  setShowSuccess: React.Dispatch<React.SetStateAction<ShowSuccess>>;
   setDepositUrl: React.Dispatch<React.SetStateAction<string>>;
+  isRemoval?: boolean;
 }
 const DepositSuccess: FC<Props> = ({
   depositUrl,
   setShowSuccess,
   setDepositUrl,
+  isRemoval = false,
 }) => {
   // Make sure we scroll to top when deposit screen mounts
   useEffect(() => {
     window.scroll(0, 0);
   }, []);
+  const message = isRemoval ? "Withdrawal succeeded" : "Deposit succeeded";
   return (
     <div>
       <DepositTopWrapper>
-        <SuccessText>Deposit succeeded</SuccessText>
+        <SuccessText>{message}</SuccessText>
         <CheckMarkWrapper>
           <Check strokeWidth={5} />
         </CheckMarkWrapper>
@@ -33,7 +37,7 @@ const DepositSuccess: FC<Props> = ({
         </EtherscanUrl>
         <DepositButton
           onClick={() => {
-            setShowSuccess(false);
+            setShowSuccess((oldShow) => ({ ...oldShow, value: false }));
             setDepositUrl("");
           }}
         >

--- a/src/components/PoolForm/PoolForm.tsx
+++ b/src/components/PoolForm/PoolForm.tsx
@@ -26,6 +26,7 @@ import {
   toWeiSafe,
 } from "utils";
 import { useConnection } from "state/hooks";
+import type { ShowSuccess } from "views/Pool";
 
 interface Props {
   symbol: string;
@@ -41,7 +42,7 @@ interface Props {
   tokenAddress: string;
   ethBalance: QuerySubState<any> | null | undefined;
   erc20Balances: QuerySubState<any> | null | undefined;
-  setShowSuccess: React.Dispatch<React.SetStateAction<boolean>>;
+  setShowSuccess: React.Dispatch<React.SetStateAction<ShowSuccess>>;
   setDepositUrl: React.Dispatch<React.SetStateAction<string>>;
   balance: string;
   wrongNetwork?: boolean;

--- a/src/components/PoolForm/PoolForm.tsx
+++ b/src/components/PoolForm/PoolForm.tsx
@@ -42,7 +42,7 @@ interface Props {
   tokenAddress: string;
   ethBalance: QuerySubState<any> | null | undefined;
   erc20Balances: QuerySubState<any> | null | undefined;
-  setShowSuccess: React.Dispatch<React.SetStateAction<ShowSuccess>>;
+  setShowSuccess: React.Dispatch<React.SetStateAction<ShowSuccess | undefined>>;
   setDepositUrl: React.Dispatch<React.SetStateAction<string>>;
   balance: string;
   wrongNetwork?: boolean;

--- a/src/components/PoolForm/RemoveLiquidityForm.tsx
+++ b/src/components/PoolForm/RemoveLiquidityForm.tsx
@@ -30,6 +30,7 @@ import {
 } from "utils";
 import BouncingDotsLoader from "components/BouncingDotsLoader";
 import api from "state/chainApi";
+import { ShowSuccess } from "views/Pool";
 
 const { previewRemoval } = umaSdk.across.clients.bridgePool;
 
@@ -42,7 +43,7 @@ interface Props {
   lpTokens: ethers.BigNumber;
   decimals: number;
   symbol: string;
-  setShowSuccess: React.Dispatch<React.SetStateAction<boolean>>;
+  setShowSuccess: React.Dispatch<React.SetStateAction<ShowSuccess>>;
   setDepositUrl: React.Dispatch<React.SetStateAction<string>>;
   balance: string;
   position: ethers.BigNumber;
@@ -121,7 +122,7 @@ const RemoveLiqudityForm: FC<Props> = ({
           emitter.on("txConfirmed", (tx) => {
             if (transaction.hash) notify.unsubscribe(transaction.hash);
             const url = `https://etherscan.io/tx/${transaction.hash}`;
-            setShowSuccess(true);
+            setShowSuccess({ type: "remove", value: true });
             setDepositUrl(url);
             setTxSubmitted(false);
             if (account)

--- a/src/components/PoolForm/RemoveLiquidityForm.tsx
+++ b/src/components/PoolForm/RemoveLiquidityForm.tsx
@@ -43,7 +43,7 @@ interface Props {
   lpTokens: ethers.BigNumber;
   decimals: number;
   symbol: string;
-  setShowSuccess: React.Dispatch<React.SetStateAction<ShowSuccess>>;
+  setShowSuccess: React.Dispatch<React.SetStateAction<ShowSuccess | undefined>>;
   setDepositUrl: React.Dispatch<React.SetStateAction<string>>;
   balance: string;
   position: ethers.BigNumber;
@@ -122,7 +122,7 @@ const RemoveLiqudityForm: FC<Props> = ({
           emitter.on("txConfirmed", (tx) => {
             if (transaction.hash) notify.unsubscribe(transaction.hash);
             const url = `https://etherscan.io/tx/${transaction.hash}`;
-            setShowSuccess({ type: "remove", value: true });
+            setShowSuccess("withdraw");
             setDepositUrl(url);
             setTxSubmitted(false);
             if (account)

--- a/src/views/Pool.tsx
+++ b/src/views/Pool.tsx
@@ -21,17 +21,11 @@ import BouncingDotsLoader from "components/BouncingDotsLoader";
 
 import { BounceType } from "components/BouncingDotsLoader/BouncingDotsLoader";
 
-export type ShowSuccess = {
-  type: "deposit" | "remove";
-  value: boolean;
-};
+export type ShowSuccess = "deposit" | "withdraw";
 
 const Pool: FC = () => {
   const [token, setToken] = useState<Token>(TOKENS_LIST[ChainId.MAINNET][2]);
-  const [showSuccess, setShowSuccess] = useState<ShowSuccess>({
-    type: "deposit",
-    value: false,
-  });
+  const [showSuccess, setShowSuccess] = useState<ShowSuccess | undefined>();
   const [depositUrl, setDepositUrl] = useState("");
   const [loadingPoolState, setLoadingPoolState] = useState(false);
   const [defaultTab, setDefaultTab] = useState("Add");
@@ -176,6 +170,7 @@ const Pool: FC = () => {
         <DepositSuccess
           depositUrl={depositUrl}
           setShowSuccess={setShowSuccess}
+          showSuccess={showSuccess}
           setDepositUrl={setDepositUrl}
         />
       )}

--- a/src/views/Pool.tsx
+++ b/src/views/Pool.tsx
@@ -21,9 +21,17 @@ import BouncingDotsLoader from "components/BouncingDotsLoader";
 
 import { BounceType } from "components/BouncingDotsLoader/BouncingDotsLoader";
 
+export type ShowSuccess = {
+  type: "deposit" | "remove";
+  value: boolean;
+};
+
 const Pool: FC = () => {
   const [token, setToken] = useState<Token>(TOKENS_LIST[ChainId.MAINNET][2]);
-  const [showSuccess, setShowSuccess] = useState(false);
+  const [showSuccess, setShowSuccess] = useState<ShowSuccess>({
+    type: "deposit",
+    value: false,
+  });
   const [depositUrl, setDepositUrl] = useState("");
   const [loadingPoolState, setLoadingPoolState] = useState(false);
   const [defaultTab, setDefaultTab] = useState("Add");


### PR DESCRIPTION
This PR fixes https://app.shortcut.com/uma-project/story/3461/when-removing-liquidity-change-deposit-succeeded-to-withdrawal-succeeded

The solution I used is a bit hacky, but was the quickest one without having to colocate the add and remove liquidity forms

Signed-off-by: Gamaranto <francesco@umaproject.org>