### PR TITLE
fix(across): change total to show individual position

### DIFF
--- a/src/components/PoolForm/PoolForm.tsx
+++ b/src/components/PoolForm/PoolForm.tsx
@@ -175,7 +175,7 @@ const PoolForm: FC<Props> = ({
         <PositionItem>
           <div>Total</div>
           <div>
-            {formatUnits(totalPoolSize, decimals)} {symbol}
+            {formatUnits(position.add(feesEarned), decimals)} {symbol}
           </div>
         </PositionItem>
       </Position>


### PR DESCRIPTION
This PR fixes : https://app.shortcut.com/uma-project/story/3696/total-should-show-the-total-earned-by-the-user-not-the-total-pool-size

Signed-off-by: Gamaranto <francesco@umaproject.org>