### PR TITLE
feat(across): ability to send funds from ethereum to boba

### DIFF
--- a/src/components/CoinSelection/CoinSelection.tsx
+++ b/src/components/CoinSelection/CoinSelection.tsx
@@ -38,6 +38,10 @@ const CoinSelection = () => {
     if (fromChain === ChainId.MAINNET && toChain === ChainId.OPTIMISM) {
       return TOKENS_LIST[sendState.currentlySelectedFromChain.chainId].slice(1);
     }
+    if (fromChain === ChainId.MAINNET && toChain === ChainId.BOBA) {
+      return TOKENS_LIST[sendState.currentlySelectedFromChain.chainId]
+        .filter((token) => ['USDC', 'ETH'].includes(token.symbol));
+    }
     return TOKENS_LIST[sendState.currentlySelectedFromChain.chainId];
   }, [fromChain, toChain, sendState.currentlySelectedFromChain.chainId]);
   const { data: balances } = useBalances(

--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -36,6 +36,7 @@ const SendAction: React.FC = () => {
     toAddress,
     approve,
     fees,
+    spender
   } = useSend();
   const { signer, account } = useConnection();
   const sendState = useAppSelector((state) => state.send);
@@ -52,14 +53,10 @@ const SendAction: React.FC = () => {
     sendState.currentlySelectedFromChain.chainId
   ].find((t) => t.address === token);
   const { error, addError, removeError } = useContext(ErrorContext);
-
-  const depositBox = getDepositBox(
-    sendState.currentlySelectedFromChain.chainId
-  );
   const { refetch } = useAllowance(
     {
       owner: account!,
-      spender: depositBox.address,
+      spender,
       chainId: sendState.currentlySelectedFromChain.chainId,
       token,
       amount,

--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -9,7 +9,6 @@ import {
 import { TransactionTypes } from "state/transactions";
 import {
   CHAINS,
-  getDepositBox,
   TOKENS_LIST,
   formatUnits,
   receiveAmount,

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -587,7 +587,6 @@ export function useSendArbitrum() {
   }, [bridge, amount, fees, token, isConnected, toAddress]);
 
   const approve = useCallback(() => {
-    debugger
     if (!bridge) return;
     return bridge.approveToken(token, MAX_APPROVAL_AMOUNT);
   }, [bridge, token]);

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -170,3 +170,13 @@ export const optimismErc20Pairs = () => {
     [umaMainnet.address]: umaOptimism.address,
   };
 };
+
+// This will be moved inside the SDK in the near future
+export const bobaErc20Pairs = () => {
+  const usdcMainnet = TOKENS_LIST[ChainId.MAINNET].filter((token) => token.symbol === "USDC")[0];
+  const usdcBoba = TOKENS_LIST[ChainId.BOBA].filter((token) => token.symbol === "USDC")[0];
+
+  return {
+    [usdcMainnet.address]: usdcBoba.address,
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2964,9 +2964,9 @@
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
 "@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0":
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.1.tgz#88d501e84b6185f6489ecee4ba9e8fcec7f29bb2"
-  integrity sha512-NXKvBVUzIbs6ylBwmOwHFkZS2EXCcjnqr8ZCRNaXBkHAf+3mn/rPcJxwrzuc6movh8fxQAsUUfYklJ/EG+hZqQ==
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.2.tgz#a4c07d47ff737e8ee7e586fe636ff0e1ddff070a"
+  integrity sha512-JepeIUPFDARgIs0zD/SKPgFsJEAF0X5/qO80llx59gOxFTboS9Amv3S+QfB7lqBId5sFXJ99BN0J6zFRvL9dDA==
 
 "@types/node@10.12.18":
   version "10.12.18"
@@ -2979,9 +2979,9 @@
   integrity sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==
 
 "@types/node@^12.0.0", "@types/node@^12.12.6":
-  version "12.20.37"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.37.tgz#abb38afa9d6e8a2f627a8cb52290b3c80fbe61ed"
-  integrity sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA==
+  version "12.20.38"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.38.tgz#74801983c0558a7a31a4ead18bce2edded2b0e2f"
+  integrity sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -3295,15 +3295,10 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
-"@uma/contracts-frontend@^0.1.17":
+"@uma/contracts-frontend@^0.1.17", "@uma/contracts-frontend@^0.1.5":
   version "0.1.17"
   resolved "https://registry.yarnpkg.com/@uma/contracts-frontend/-/contracts-frontend-0.1.17.tgz#141760bf6d783ddfbe94ce5cfeff410d2e73311a"
   integrity sha512-sRWCFEC56DyBd+QcCPGoJghG9lAE8VQvcYpW9CSvyOLmSz+eugy1pxbOBg6v6qkGqexO1vCp608TkG71vaQqUg==
-
-"@uma/contracts-frontend@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@uma/contracts-frontend/-/contracts-frontend-0.1.5.tgz#d0300642b5f32b57b939e504325ee6e88d1d45f9"
-  integrity sha512-+rgW6B0/HZXZXGuW2uVv6rag/dlRJm4VoEVvu5YwCAO+XrP161dLvRRP13KplkIqRIIAOor51Jdiq3XgrhAbkw==
 
 "@uma/contracts-node@^0.1.17":
   version "0.1.17"
@@ -5300,9 +5295,9 @@ bnc-notify@^1.9.1:
     uuid "^3.3.3"
 
 bnc-onboard@^1.35.2:
-  version "1.36.0"
-  resolved "https://registry.yarnpkg.com/bnc-onboard/-/bnc-onboard-1.36.0.tgz#ba870b47250a7c51becc924fa78097dbf75d5e67"
-  integrity sha512-+DzM3y4FiSo12VfWPTYKGIGPAyrS98H9fAkUlcBCx9guWCMTTYxlxWv09wq+6DuhCPZ1zMcItWxjZipzf/7KUw==
+  version "1.37.0"
+  resolved "https://registry.yarnpkg.com/bnc-onboard/-/bnc-onboard-1.37.0.tgz#837238933b7461d898bc8dfb3e56354004237b44"
+  integrity sha512-B1itICd54MUhbwTycRX03p5f2DgRmQmJ3TLbUugVfjEJW1hYdhZ3w2JWaiDiQrCPDdmu4qSook7RUghZrBi7Zg==
   dependencies:
     "@cvbb/eth-keyring" "^1.1.0"
     "@ensdomains/ensjs" "^2.0.1"


### PR DESCRIPTION
Add support for L1 -> Boba transfers

Found a bug that was preventing the `Send` button to appear after a successful `Approve` action. It happened because, after approving, the app was checking the allowance for the deposit box, not for Optimism/Arbitrum/Boba Bridge contract