### PR TITLE
feat(across): add dropdown mobile view

### DIFF
--- a/src/components/AddressSelection/AddressSelection.styles.ts
+++ b/src/components/AddressSelection/AddressSelection.styles.ts
@@ -17,18 +17,13 @@ export const RoundBox = styled(UnstyledBox)`
   --color: var(--color-white);
   --outline-color: var(--color-primary);
   background-color: var(--color);
-  font-size: ${16 / 16}rem;
+  display: block;
   padding: 10px 15px;
   margin-top: 16px;
   margin-right: auto;
   margin-left: auto;
-  flex: 2;
-  display: flex;
   &:not(:first-of-type):focus-within {
     outline: var(--outline-color) solid 1px;
-  }
-  &:first-of-type {
-    flex: 1;
   }
 `;
 
@@ -58,7 +53,7 @@ export const ChangeWrapper = styled.div`
 export const ChangeButton = styled.div`
   color: #6cf9d8;
   font-size: 0.8rem;
-  font-family: "Barlow";
+
   cursor: pointer;
   margin-top: 4px;
   &.disabled {
@@ -179,11 +174,12 @@ export const Item = motion(styled.li`
 `);
 
 export const ToggleIcon = styled(ChevronDown)`
-  margin-left: 250px;
+  margin-left: auto;
 `;
 
 export const ToggleButton = styled.button`
   --radius: 30px;
+  width: 100%;
   padding: 0;
   margin: 0;
   font-size: inherit;
@@ -196,7 +192,6 @@ export const ToggleButton = styled.button`
 
 export const InputGroup = styled.div`
   position: relative;
-  display: flex;
   width: 100%;
 `;
 

--- a/src/components/ChainSelection/ChainSelection.styles.tsx
+++ b/src/components/ChainSelection/ChainSelection.styles.tsx
@@ -14,19 +14,13 @@ export const RoundBox = styled(UnstyledBox)`
   --color: var(--color-white);
   --outline-color: var(--color-primary);
   background-color: var(--color);
-  font-size: ${16 / 16}rem;
+  display: block;
   padding: 10px 15px;
   margin-top: 16px;
   margin-right: auto;
   margin-left: auto;
-  flex: 2;
-  display: flex;
   &:not(:first-of-type):focus-within {
     outline: var(--outline-color) solid 1px;
-  }
-  &:first-of-type {
-    /* margin-right: 16px; */
-    flex: 1;
   }
 `;
 
@@ -109,11 +103,12 @@ export const Item = motion(styled.li`
 `);
 
 export const ToggleIcon = styled(ChevronDown)`
-  margin-left: 250px;
+  margin-left: auto;
 `;
 
 export const ToggleButton = styled.button`
   --radius: 30px;
+  width: 100%;
   padding: 0;
   margin: 0;
   font-size: inherit;
@@ -126,7 +121,6 @@ export const ToggleButton = styled.button`
 
 export const InputGroup = styled.div`
   position: relative;
-  display: flex;
   width: 100%;
 `;
 

--- a/src/components/CoinSelection/CoinSelection.styles.ts
+++ b/src/components/CoinSelection/CoinSelection.styles.ts
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import { SecondaryButtonWithoutShadow } from "../Buttons";
 import { ChevronDown } from "react-feather";
 import { motion } from "framer-motion";
-import { COLORS } from "utils";
+import { COLORS, QUERIES } from "utils";
 import { RoundBox as UnstyledBox, ErrorBox as UnstyledErrorBox } from "../Box";
 
 export const Wrapper = styled.div`
@@ -17,24 +17,32 @@ export const RoundBox = styled(UnstyledBox)`
   font-size: ${16 / 16}rem;
   padding: 10px 15px;
   margin-top: 16px;
-  flex: 2;
   display: flex;
+  @media ${QUERIES.tabletAndUp} {
+    flex: 2;
+    &:first-of-type {
+      margin-right: 16px;
+      flex: 1;
+    }
+  }
+
   &:not(:first-of-type):focus-within {
     outline: var(--outline-color) solid 1px;
-  }
-  &:first-of-type {
-    margin-right: 16px;
-    flex: 1;
   }
 `;
 
 export const InputGroup = styled.div`
   position: relative;
   display: flex;
+  flex-direction: column;
+  @media ${QUERIES.tabletAndUp} {
+    flex-direction: row;
+  }
 `;
 
 export const ToggleButton = styled.button`
   --radius: 30px;
+  width: 100%;
   padding: 0;
   margin: 0;
   font-size: inherit;
@@ -58,12 +66,15 @@ export const Menu = styled.ul`
   bottom: 0;
   right: 0;
   padding-top: 10px;
-  transform: translateY(100%);
+  transform: translateY(50%);
   box-shadow: inset 0 8px 8% rgba(45, 46, 51, 0.2);
   list-style: none;
   display: flex;
   flex-direction: column;
   z-index: 1;
+  @media ${QUERIES.tabletAndUp} {
+    transform: translateY(100%);
+  }
 `;
 
 export const Item = motion(styled.li`
@@ -93,7 +104,7 @@ export const Item = motion(styled.li`
 `);
 
 export const ToggleIcon = styled(ChevronDown)`
-  margin-left: 60px;
+  margin-left: auto;
 `;
 
 export const MaxButton = styled(SecondaryButtonWithoutShadow)`

--- a/src/components/CoinSelection/CoinSelection.tsx
+++ b/src/components/CoinSelection/CoinSelection.tsx
@@ -50,12 +50,15 @@ const CoinSelection = () => {
     { skip: !account }
   );
   const tokenBalanceMap = useMemo(() => {
-    return TOKENS_LIST[sendState.currentlySelectedFromChain.chainId].reduce((acc, val, idx) => {
-      return {
-        ...acc,
-        [val.address]: balances ? balances[idx] : undefined,
-      };
-    }, {} as Record<string, BigNumber | undefined>);
+    return TOKENS_LIST[sendState.currentlySelectedFromChain.chainId].reduce(
+      (acc, val, idx) => {
+        return {
+          ...acc,
+          [val.address]: balances ? balances[idx] : undefined,
+        };
+      },
+      {} as Record<string, BigNumber | undefined>
+    );
   }, [balances, sendState.currentlySelectedFromChain.chainId]);
 
   const [dropdownItem, setDropdownItem] = useState(() =>
@@ -64,14 +67,16 @@ const CoinSelection = () => {
 
   // Adjust coin dropdown when chain id changes, as some tokens don't exist on all chains.
   useEffect(() => {
-    const newToken = tokenList.find((t) => t.address === ethers.constants.AddressZero);
+    const newToken = tokenList.find(
+      (t) => t.address === ethers.constants.AddressZero
+    );
     setInputAmount("");
     // since we are resetting input to 0, reset any errors
     setError(undefined);
     setAmount({ amount: BigNumber.from("0") });
     setDropdownItem(() => newToken);
     setToken({ token: newToken?.address || "" });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sendState.currentlySelectedFromChain.chainId, tokenList]);
 
   const {
@@ -205,29 +210,6 @@ const CoinSelection = () => {
                 <ToggleIcon />
               </ToggleButton>
             </RoundBox>
-            <Menu {...getMenuProps()}>
-              {isOpen &&
-                tokenList.map((token, index) => (
-                  <Item
-                    {...getItemProps({ item: token, index })}
-                    initial={{ y: -10 }}
-                    animate={{ y: 0 }}
-                    exit={{ y: -10 }}
-                    key={token.address}
-                  >
-                    <Logo src={token.logoURI} alt={token.name} />
-                    <div>{token.name}</div>
-                    <div>
-                      {tokenBalanceMap &&
-                        formatUnits(
-                          tokenBalanceMap[token.address] || "0",
-                          tokenList[index].decimals
-                        )}
-                    </div>
-                  </Item>
-                ))}
-            </Menu>
-
             <RoundBox
               as="label"
               htmlFor="amount"
@@ -251,6 +233,28 @@ const CoinSelection = () => {
                 onChange={handleChange}
               />
             </RoundBox>
+            <Menu {...getMenuProps()}>
+              {isOpen &&
+                tokenList.map((token, index) => (
+                  <Item
+                    {...getItemProps({ item: token, index })}
+                    initial={{ y: -10 }}
+                    animate={{ y: 0 }}
+                    exit={{ y: -10 }}
+                    key={token.address}
+                  >
+                    <Logo src={token.logoURI} alt={token.name} />
+                    <div>{token.name}</div>
+                    <div>
+                      {tokenBalanceMap &&
+                        formatUnits(
+                          tokenBalanceMap[token.address] || "0",
+                          tokenList[index].decimals
+                        )}
+                    </div>
+                  </Item>
+                ))}
+            </Menu>
           </InputGroup>
           {showError && <ErrorBox>{errorMsg}</ErrorBox>}
         </Wrapper>

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "@emotion/styled";
-import { COLORS } from "utils";
+import { COLORS, QUERIES } from "utils";
 import { ReactComponent as UnstyledUmaLogo } from "assets/Across-Powered-UMA.svg";
 import { ReactComponent as DiscordLogo } from "assets/disc-logo.svg";
 import { ReactComponent as TwitterLogo } from "assets/icon-twitter.svg";
@@ -27,7 +27,7 @@ const TWITTER_LINK = {
 
 const Layout: React.FC = ({ children }) => (
   <Wrapper>
-    <Footer>
+    <LinkFooter>
       {NAV_LINKS.map((link) => (
         <Link
           key={link.name}
@@ -44,9 +44,9 @@ const Layout: React.FC = ({ children }) => (
       <Link href={TWITTER_LINK.url} target="_blank" rel="noopener noreferrer">
         <TwitterLogo />
       </Link>
-    </Footer>
+    </LinkFooter>
     <Main>{children}</Main>
-    <Footer>
+    <LogoFooter>
       <AccentLink
         href="https://umaproject.org"
         target="_blank"
@@ -54,29 +54,41 @@ const Layout: React.FC = ({ children }) => (
       >
         <PoweredByUMA />
       </AccentLink>
-    </Footer>
+    </LogoFooter>
   </Wrapper>
 );
 
 export default Layout;
 
-const Footer = styled.footer`
+const BaseFooter = styled.footer`
   position: sticky;
   bottom: 0;
   padding: 0 15px 15px;
   align-self: self-end;
   justify-self: center;
+`;
 
-  &:first-of-type {
-    display: flex;
-    padding-bottom: 25px;
-    & svg {
-      width: 25px;
-      height: 25px;
-      & path {
-        fill: currentColor;
-      }
+const LinkFooter = styled(BaseFooter)`
+  display: none;
+  padding-bottom: 25px;
+  & svg {
+    width: 25px;
+    height: 25px;
+    & path {
+      fill: currentColor;
     }
+  }
+  @media ${QUERIES.tabletAndUp} {
+    display: flex;
+  }
+`;
+
+const LogoFooter = styled(BaseFooter)`
+  position: absolute;
+  right: 10px;
+  @media ${QUERIES.tabletAndUp} {
+    position: sticky;
+    right: revert;
   }
 `;
 
@@ -102,7 +114,6 @@ const AccentLink = styled(Link)`
 
 const PoweredByUMA = styled(UnstyledUmaLogo)`
   fill: currentColor;
-
   transition: fill linear 100ms;
   & path {
     fill: currentColor;
@@ -110,10 +121,14 @@ const PoweredByUMA = styled(UnstyledUmaLogo)`
 `;
 
 const Wrapper = styled.div`
+  position: relative;
   display: grid;
-  padding: 0 30px;
-  grid-template-columns: 1fr var(--central-content) 1fr;
+  padding: 0 10px;
+  grid-template-columns: 1fr min(var(--central-content), 100%) 1fr;
   height: 100%;
+  @media ${QUERIES.tabletAndUp} {
+    padding: 0 30px;
+  }
 `;
 
 const Main = styled.main`


### PR DESCRIPTION
This PR makes the dropdown and the central content in across compatible with mobile screens. 

Here is some before and after screenshots:
Before:
<img width="449" alt="CleanShot 2021-12-29 at 14 28 45@2x" src="https://user-images.githubusercontent.com/29527327/147667223-f10277d7-ee23-4e76-8a91-73087d3d8fc0.png">

After:
<img width="424" alt="CleanShot 2021-12-29 at 14 29 15@2x" src="https://user-images.githubusercontent.com/29527327/147667260-f8e58dcb-0221-4292-9220-b1d3dc371c8e.png">


It still looks broken as the headers still overflow and there is some space at the bottom, but those things will be fixed in a PR that fixes the headers, so for reviewing / QAing this, just focus on the body and the dropdowns.

Related to: https://app.shortcut.com/uma-project/story/2676/ability-for-across-bridge-tab-to-work-on-mobile

Signed-off-by: Gamaranto <francesco@umaproject.org>