### PR TITLE
fix: update estimation time on chain switch

### DIFF
--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -32,7 +32,6 @@ const CONFIRMATIONS = 1;
 const SendAction: React.FC = () => {
   const {
     amount,
-    toChain,
     token,
     send,
     hasToApprove,
@@ -178,7 +177,12 @@ const SendAction: React.FC = () => {
               </Info>
             )}
             <Info>
-              <div>Native Bridge Fee</div>
+              <div>
+                {sendState.currentlySelectedFromChain.chainId ===
+                ChainId.MAINNET
+                  ? "Native Bridge Fee"
+                  : "Bridge Fee"}
+              </div>
               <div>
                 {sendState.currentlySelectedFromChain.chainId ===
                 ChainId.MAINNET

--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -161,7 +161,9 @@ const SendAction: React.FC = () => {
                 Time to{" "}
                 {CHAINS[sendState.currentlySelectedToChain.chainId].name}
               </div>
-              <div>{getEstimatedDepositTime(toChain)}</div>
+              <div>
+                {getEstimatedDepositTime(sendState.currentlySelectedToChain.chainId)}
+              </div>
             </Info>
             {sendState.currentlySelectedFromChain.chainId !==
               ChainId.MAINNET && (


### PR DESCRIPTION
Bug: the bridging estimation time was not updating when switching back to L2 -> L1