### PR TITLE
fix(across): remove outline for toggle button

### DIFF
--- a/src/components/Header/MenuToggle.tsx
+++ b/src/components/Header/MenuToggle.tsx
@@ -64,6 +64,7 @@ const CloseButton = styled.button`
   padding: 0;
   margin: 0;
   border: none;
+  outline: none;
   background-color: transparent;
   cursor: pointer;
   outline: none;


### PR DESCRIPTION
Removes outline for toggle button on mobile (may the accessibility gods have mercy)

Signed-off-by: Gamaranto <francesco@umaproject.org>