### PR TITLE
fix(across): disable zoom on input on iOS

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,11 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/logo-small.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1"
+    />
+
     <meta name="theme-color" content="#6CF9D8" />
     <meta
       name="description"

--- a/src/components/Dialog/Dialog.styles.tsx
+++ b/src/components/Dialog/Dialog.styles.tsx
@@ -8,11 +8,11 @@ export const Wrapper = styled(DialogContent)`
   background-color: var(--color-primary);
   color: var(--color-gray);
   border-radius: 12px;
-  width: 440px;
   max-width: 440px;
+  width: min(440px, calc(100% - 20px));
   top: 10vh;
   overflow: auto;
-  min-height: 60vh;
+  min-height: min(60vh, fit-content);
   max-height: 80vh;
   @media ${QUERIES.mobileAndDown} {
     top: 25%;

--- a/src/components/Dialog/Dialog.styles.tsx
+++ b/src/components/Dialog/Dialog.styles.tsx
@@ -12,7 +12,7 @@ export const Wrapper = styled(DialogContent)`
   width: min(440px, calc(100% - 20px));
   top: 10vh;
   overflow: auto;
-  min-height: min(60vh, fit-content);
+  min-height: 60vh;
   max-height: 80vh;
   @media ${QUERIES.mobileAndDown} {
     top: 25%;

--- a/src/components/GlobalStyles/GlobalStyles.tsx
+++ b/src/components/GlobalStyles/GlobalStyles.tsx
@@ -85,6 +85,17 @@ const globalStyles = css`
     height: 100%;
     isolation: isolate;
   }
+  // iphone query
+  @media screen and (-webkit-min-device-pixel-ratio: 2) {
+    select,
+    select:focus,
+    textarea,
+    textarea:focus,
+    input,
+    input:focus {
+      font-size: 16px;
+    }
+  }
 
   ${typography}
   ${variables}


### PR DESCRIPTION
This PR disables the zooming on iOS devices on inputs by setting inputs font-size to 16px