### PR TITLE
fix(across): fix negative 0 on iOS

### DIFF
--- a/src/components/PoolForm/PoolForm.tsx
+++ b/src/components/PoolForm/PoolForm.tsx
@@ -160,7 +160,8 @@ const PoolForm: FC<Props> = ({
         <PositionItem>
           <div>My deposit</div>
           <div>
-            {formatUnits(position, decimals)} {symbol}
+            {/* This can never be < 0, but for some weird iOS bug it shows -0 on mobile */}
+            {formatUnits(position, decimals).replace("-", "")} {symbol}
           </div>
         </PositionItem>
         <PositionItem>


### PR DESCRIPTION
Removes the "-" in front of the position, it sometimes showed -0 on iOS
Signed-off-by: Gamaranto <francesco@umaproject.org>