### PR TITLE
make it clear that users are getting wrapped eth

### DIFF
--- a/src/components/AddressSelection/AddressSelection.tsx
+++ b/src/components/AddressSelection/AddressSelection.tsx
@@ -184,6 +184,7 @@ const AddressSelection: React.FC = () => {
                 Change account
               </ChangeButton>
             </ChangeWrapper>
+            <div>Note: All ETH transfered to L1 appears as WETH</div>
           )}
         </Wrapper>
         <Dialog isOpen={open} onClose={toggle}>


### PR DESCRIPTION
People expect eth when they look at this screen:

![Screenshot(10)](https://user-images.githubusercontent.com/803976/149402839-4c0da27c-c8fc-452b-8162-352aa22c8b68.png)

and can get into problems if they get given wrapped eth unknowingly. Somehow we need to make it clearer so that people do not run into problems.