### PR TITLE
fix(across): remove outline for mobile menu

### DIFF
--- a/src/components/Header/Header.styles.tsx
+++ b/src/components/Header/Header.styles.tsx
@@ -53,6 +53,7 @@ export const BaseLink = styled(UnstyledLink)`
   display: block;
   text-decoration: none;
   color: inherit;
+  outline: none;
   height: 100%;
   width: 100%;
 `;

--- a/src/components/Header/Header.styles.tsx
+++ b/src/components/Header/Header.styles.tsx
@@ -94,6 +94,7 @@ export const MobileList = styled.ul`
   display: flex;
   list-style: none;
   flex-direction: column;
+  outline: none;
   color: var(--color-gray);
 `;
 


### PR DESCRIPTION
This PR removes the outline from the mobile menu