### PR TITLE
across(fix): show eth received only when sending from optimism

### DIFF
--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -151,7 +151,8 @@ const SendAction: React.FC = () => {
     (hasToApprove && !canApprove) ||
     amountMinusFees.lte(0);
 
-  const isWETH = tokenInfo?.symbol === "WETH";
+  const shouldShowWETHAsETH =
+    tokenInfo?.symbol === "WETH" && sendState.fromChain === ChainId.OPTIMISM;
 
   return (
     <AccentSection>
@@ -201,7 +202,7 @@ const SendAction: React.FC = () => {
               <div>You will receive</div>
               <div>
                 {formatUnits(amountMinusFees, tokenInfo.decimals)}{" "}
-                {isWETH ? "ETH" : tokenInfo.symbol}
+                {shouldShowWETHAsETH ? "ETH" : tokenInfo.symbol}
               </div>
             </Info>
             <InfoIcon aria-label="info dialog" onClick={toggleInfoModal} />

--- a/src/views/Confirmation/Confirmation.tsx
+++ b/src/views/Confirmation/Confirmation.tsx
@@ -37,7 +37,8 @@ const Confirmation: React.FC = () => {
   const tokenInfo = TOKENS_LIST[deposit.fromChain].find(
     (t) => t.address === deposit.token
   );
-  const isWETH = tokenInfo?.symbol === "WETH";
+  const shouldShowWETHAsETH =
+    tokenInfo?.symbol === "WETH" && deposit.fromChain === ChainId.OPTIMISM;
 
   return (
     <Layout>
@@ -82,18 +83,27 @@ const Confirmation: React.FC = () => {
                 <h3>Receiving</h3>
                 <div>
                   <Logo
-                    src={isWETH ? MAINNET_ETH?.logoURI : tokenInfo?.logoURI}
+                    src={
+                      shouldShowWETHAsETH
+                        ? MAINNET_ETH?.logoURI
+                        : tokenInfo?.logoURI
+                    }
                     alt={`${
-                      isWETH ? MAINNET_ETH?.symbol : tokenInfo?.symbol
+                      shouldShowWETHAsETH
+                        ? MAINNET_ETH?.symbol
+                        : tokenInfo?.symbol
                     } logo`}
                   />
                   <div>
                     {formatUnits(
                       amountMinusFees,
-                      (isWETH ? MAINNET_ETH?.decimals : tokenInfo?.decimals) ??
-                        18
+                      (shouldShowWETHAsETH
+                        ? MAINNET_ETH?.decimals
+                        : tokenInfo?.decimals) ?? 18
                     )}{" "}
-                    {isWETH ? MAINNET_ETH?.symbol : tokenInfo?.symbol}
+                    {shouldShowWETHAsETH
+                      ? MAINNET_ETH?.symbol
+                      : tokenInfo?.symbol}
                   </div>
                 </div>
               </Info>


### PR DESCRIPTION
This PR adds the condition that the fromChain must be Optimism if ETH is shown instead of WETH.

Note: It would be nice to have a general way to handle those cross-chain quirks, but for now, I just added and additional condition to a boolean flag.
Signed-off-by: Gamaranto <francesco@umaproject.org>