### PR TITLE
across(fix): make powered by uma not overlap

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -125,7 +125,8 @@ const Wrapper = styled.div`
   display: grid;
   padding: 0 10px;
   grid-template-columns: 1fr min(var(--central-content), 100%) 1fr;
-  height: 100%;
+  min-height: 100%;
+  height: fit-content;
   @media ${QUERIES.tabletAndUp} {
     padding: 0 30px;
   }


### PR DESCRIPTION
Before:
<img width="270" alt="CleanShot 2022-01-17 at 10 32 45@2x" src="https://user-images.githubusercontent.com/29527327/149744146-4d1bbd2c-8c2b-4b9c-8572-4135ff3b8c41.png">

After:
<img width="296" alt="CleanShot 2022-01-17 at 10 32 23@2x" src="https://user-images.githubusercontent.com/29527327/149744068-ff9d1776-91b5-4638-836f-1b7372c231ee.png">


Signed-off-by: Gamaranto <francesco@umaproject.org>