### PR TITLE
across(fix): reduce space over from on mobile

### DIFF
--- a/src/components/ChainSelection/ChainSelection.styles.tsx
+++ b/src/components/ChainSelection/ChainSelection.styles.tsx
@@ -1,13 +1,16 @@
 import styled from "@emotion/styled";
 import { PrimaryButton } from "../Buttons";
 import { RoundBox as UnstyledBox } from "../Box";
+import { QUERIES } from "utils";
 import { ChevronDown } from "react-feather";
 import { motion } from "framer-motion";
 
 export const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
-  padding-top: 20px;
+  @media ${QUERIES.tabletAndUp} {
+    padding-top: 20px;
+  }
 `;
 
 export const RoundBox = styled(UnstyledBox)`

--- a/src/components/ChainSelection/ChainSelection.styles.tsx
+++ b/src/components/ChainSelection/ChainSelection.styles.tsx
@@ -8,6 +8,7 @@ import { motion } from "framer-motion";
 export const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
+  padding-top: 15px;
   @media ${QUERIES.tabletAndUp} {
     padding-top: 20px;
   }

--- a/src/components/PoolSelection/PoolSelection.styles.ts
+++ b/src/components/PoolSelection/PoolSelection.styles.ts
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { ChevronDown } from "react-feather";
 import { motion } from "framer-motion";
-import { COLORS } from "utils";
+import { COLORS, QUERIES } from "utils";
 import { RoundBox as UnstyledBox, ErrorBox as UnstyledErrorBox } from "../Box";
 import { Section } from "../Section";
 
@@ -10,7 +10,9 @@ export const Wrapper = styled(Section)`
   border-bottom: none;
   display: flex;
   flex-direction: column;
-  padding-top: 30px;
+  @media ${QUERIES.tabletAndUp} {
+    padding-top: 30px;
+  }
 `;
 export const RoundBox = styled(UnstyledBox)`
   --color: var(--color-white);

--- a/src/components/PoolSelection/PoolSelection.styles.ts
+++ b/src/components/PoolSelection/PoolSelection.styles.ts
@@ -10,6 +10,7 @@ export const Wrapper = styled(Section)`
   border-bottom: none;
   display: flex;
   flex-direction: column;
+  padding-top: 15px;
   @media ${QUERIES.tabletAndUp} {
     padding-top: 30px;
   }

--- a/src/components/Section/Section.tsx
+++ b/src/components/Section/Section.tsx
@@ -5,7 +5,7 @@ import { QUERIES } from "utils";
 export const Section = styled.section`
   color: var(--color-white);
   border-bottom: 1px solid var(--color-primary-dark);
-  padding: 10px 10px 20px;
+  padding: 0px 10px 20px;
   @media ${QUERIES.tabletAndUp} {
     padding: 10px 30px 25px;
   }


### PR DESCRIPTION
Before:
<img width="494" alt="CleanShot 2022-01-25 at 16 36 16@2x" src="https://user-images.githubusercontent.com/29527327/151008040-6e4f3306-a383-4adb-b80d-874e220067a0.png">


After:

<img width="496" alt="CleanShot 2022-01-25 at 16 36 28@2x" src="https://user-images.githubusercontent.com/29527327/151008064-3cdde30e-cfff-4d8f-8ad2-54dd9b5f5db6.png">



Signed-off-by: Gamaranto <francesco@umaproject.org>