### PR TITLE
across(fix): move modals upwards on mobile

### DIFF
--- a/src/components/Dialog/Dialog.styles.tsx
+++ b/src/components/Dialog/Dialog.styles.tsx
@@ -11,11 +11,11 @@ export const Wrapper = styled(DialogContent)`
   border-radius: 12px;
   max-width: 440px;
   width: min(440px, calc(100% - 20px));
-  top: 10vh;
+  top: 10%;
   overflow: auto;
   min-height: 60vh;
   max-height: 80vh;
-  @media ${QUERIES.mobileAndDown} {
+  @media ${QUERIES.tabletAndUp} {
     top: 25%;
   }
 `;


### PR DESCRIPTION
Before:
https://media.app.shortcut.com/api/attachments/files/clubhouse-assets/6050e9f3-ea3b-48d1-a78e-efcdcae6ce04/61f06c7f-7873-45e9-a667-7050aab717cd/IMG_2836.PNG

After:
![telegram-cloud-photo-size-4-6025956734423644420-y](https://user-images.githubusercontent.com/29527327/151539161-da6bde05-f30f-475c-b569-ceca1e6021ab.jpg)

Signed-off-by: Gamaranto <francesco@umaproject.org>