### PR TITLE
fix(across): remove outline from menu

### DIFF
--- a/src/components/Header/MobileMenu.tsx
+++ b/src/components/Header/MobileMenu.tsx
@@ -28,4 +28,5 @@ export const Overlay = styled(DialogOverlay)`
 
 const Content = styled(DialogContent)`
   padding: 10px;
+  outline: none;
 `;


### PR DESCRIPTION
This PR removes the outline from the mobile menu, 
Before: 
![image](https://user-images.githubusercontent.com/29527327/152787575-c829f98e-d82c-41f0-b759-320b3f7408c2.png)

After: same but with no outline

Signed-off-by: Gamaranto <francesco@umaproject.org>