### PR TITLE
feat: default users to the chain they have selected on clicking connect wallet

### DIFF
--- a/src/components/AddressSelection/AddressSelection.tsx
+++ b/src/components/AddressSelection/AddressSelection.tsx
@@ -45,21 +45,21 @@ const AddressSelection: React.FC = () => {
     sendState.currentlySelectedToChain
   );
 
-  console.log("CID", chainId, "sendState", sendState);
   useEffect(() => {
-    if (chainId && chainId !== sendState.fromChain) {
-      const notFindChain = CHAINS_SELECTION.filter(
-        (x) => x.chainId !== chainId
-      );
-      if (notFindChain) {
-        setDropdownValue(notFindChain[0]);
-        dispatch(
-          actions.updateSelectedToChain(notFindChain[notFindChain.length - 1])
-        );
-      }
-    }
+    // if (chainId && chainId !== sendState.fromChain) {
+    //   const notFindChain = CHAINS_SELECTION.filter(
+    //     (x) => x.chainId !== chainId
+    //   );
+    //   if (notFindChain) {
+    //     setDropdownValue(notFindChain[0]);
+    //     dispatch(
+    //       actions.updateSelectedToChain(notFindChain[notFindChain.length - 1])
+    //     );
+    //   }
+    // }
+    setDropdownValue(sendState.currentlySelectedToChain);
     // setDropdownValue(sendState.currentlySelectedFromChain);
-  }, [chainId, sendState.fromChain, dispatch]);
+  }, [chainId, sendState.currentlySelectedToChain, dispatch]);
 
   const {
     isOpen,
@@ -74,6 +74,7 @@ const AddressSelection: React.FC = () => {
     selectedItem: dropdownValue,
     onSelectedItemChange: ({ selectedItem }) => {
       if (selectedItem) {
+        setDropdownValue(selectedItem);
         const nextState = { ...sendState, toChain: selectedItem.chainId };
         dispatch(actions.toChain(nextState));
         dispatch(actions.updateSelectedToChain(selectedItem));

--- a/src/components/AddressSelection/AddressSelection.tsx
+++ b/src/components/AddressSelection/AddressSelection.tsx
@@ -34,13 +34,32 @@ import { actions } from "state/send";
 import { AnimatePresence } from "framer-motion";
 
 const AddressSelection: React.FC = () => {
-  const { isConnected } = useConnection();
+  const { isConnected, chainId } = useConnection();
   const { toChain, toAddress, fromChain, setToAddress } = useSend();
   const [address, setAddress] = useState("");
   const [open, setOpen] = useState(false);
   const dispatch = useAppDispatch();
 
   const sendState = useAppSelector((state) => state.send);
+  const [dropdownValue, setDropdownValue] = useState(
+    sendState.currentlySelectedToChain
+  );
+
+  console.log("CID", chainId, "sendState", sendState);
+  useEffect(() => {
+    if (chainId && chainId !== sendState.fromChain) {
+      const notFindChain = CHAINS_SELECTION.filter(
+        (x) => x.chainId !== chainId
+      );
+      if (notFindChain) {
+        setDropdownValue(notFindChain[0]);
+        dispatch(
+          actions.updateSelectedToChain(notFindChain[notFindChain.length - 1])
+        );
+      }
+    }
+    // setDropdownValue(sendState.currentlySelectedFromChain);
+  }, [chainId, sendState.fromChain, dispatch]);
 
   const {
     isOpen,
@@ -51,8 +70,8 @@ const AddressSelection: React.FC = () => {
     getMenuProps,
   } = useSelect({
     items: CHAINS_SELECTION,
-    defaultSelectedItem: sendState.currentlySelectedToChain,
-    selectedItem: sendState.currentlySelectedToChain,
+    defaultSelectedItem: dropdownValue,
+    selectedItem: dropdownValue,
     onSelectedItemChange: ({ selectedItem }) => {
       if (selectedItem) {
         const nextState = { ...sendState, toChain: selectedItem.chainId };

--- a/src/components/AddressSelection/AddressSelection.tsx
+++ b/src/components/AddressSelection/AddressSelection.tsx
@@ -34,7 +34,7 @@ import { actions } from "state/send";
 import { AnimatePresence } from "framer-motion";
 
 const AddressSelection: React.FC = () => {
-  const { isConnected, chainId } = useConnection();
+  const { isConnected } = useConnection();
   const { toChain, toAddress, fromChain, setToAddress } = useSend();
   const [address, setAddress] = useState("");
   const [open, setOpen] = useState(false);
@@ -45,21 +45,10 @@ const AddressSelection: React.FC = () => {
     sendState.currentlySelectedToChain
   );
 
+  // If somehow currentlySelectedToChain is changed externally, make sure the dropdown maps to it.
   useEffect(() => {
-    // if (chainId && chainId !== sendState.fromChain) {
-    //   const notFindChain = CHAINS_SELECTION.filter(
-    //     (x) => x.chainId !== chainId
-    //   );
-    //   if (notFindChain) {
-    //     setDropdownValue(notFindChain[0]);
-    //     dispatch(
-    //       actions.updateSelectedToChain(notFindChain[notFindChain.length - 1])
-    //     );
-    //   }
-    // }
     setDropdownValue(sendState.currentlySelectedToChain);
-    // setDropdownValue(sendState.currentlySelectedFromChain);
-  }, [chainId, sendState.currentlySelectedToChain, dispatch]);
+  }, [sendState.currentlySelectedToChain]);
 
   const {
     isOpen,

--- a/src/components/ChainSelection/ChainSelection.tsx
+++ b/src/components/ChainSelection/ChainSelection.tsx
@@ -19,6 +19,7 @@ import { useSelect } from "downshift";
 import { CHAINS_SELECTION } from "utils/constants";
 import { actions } from "state/send";
 import { useAppDispatch, useAppSelector } from "state/hooks";
+import usePrevious from "hooks/usePrevious";
 
 const ChainSelection: React.FC = () => {
   const { init } = onboard;
@@ -31,19 +32,34 @@ const ChainSelection: React.FC = () => {
     sendState.currentlySelectedFromChain
   );
 
+  /*
+    The following block will attempt to change the dropdown when the user connects the app.
+
+    Otherwise, it just makes sure to map the dropdown value when the currentSelected block changes.
+
+    This will also change the dropdown value in <AddressSelection /> because of the hook in there.
+  */
+  const previousChainId = usePrevious(chainId);
   useEffect(() => {
-    // if (chainId && chainId !== sendState.fromChain) {
-    //   const findChain = CHAINS_SELECTION.find((x) => x.chainId === chainId);
-    //   const notFindChain = CHAINS_SELECTION.filter(
-    //     (x) => x.chainId !== chainId
-    //   );
-    //   if (findChain && notFindChain) {
-    //     setDropdownValue(findChain);
-    //     dispatch(actions.updateSelectedFromChain(findChain));
-    //   }
-    // }
-    setDropdownValue(sendState.currentlySelectedFromChain);
-  }, [chainId, sendState.currentlySelectedFromChain, dispatch]);
+    if (chainId && previousChainId === undefined) {
+      const findChain = CHAINS_SELECTION.find((x) => x.chainId === chainId);
+      const notFindChain = CHAINS_SELECTION.filter(
+        (x) => x.chainId !== chainId
+      );
+      if (findChain && notFindChain) {
+        setDropdownValue(findChain);
+        dispatch(actions.updateSelectedFromChain(findChain));
+        dispatch(actions.updateSelectedToChain(notFindChain[0]));
+      }
+    } else {
+      setDropdownValue(sendState.currentlySelectedFromChain);
+    }
+  }, [
+    chainId,
+    previousChainId,
+    sendState.currentlySelectedFromChain,
+    dispatch,
+  ]);
 
   const wrongNetworkSend =
     provider &&

--- a/src/components/ChainSelection/ChainSelection.tsx
+++ b/src/components/ChainSelection/ChainSelection.tsx
@@ -32,7 +32,7 @@ const ChainSelection: React.FC = () => {
   );
 
   useEffect(() => {
-    if (chainId !== sendState.fromChain) {
+    if (chainId && chainId !== sendState.fromChain) {
       const findChain = CHAINS_SELECTION.find((x) => x.chainId === chainId);
       const notFindChain = CHAINS_SELECTION.filter(
         (x) => x.chainId !== chainId
@@ -40,15 +40,11 @@ const ChainSelection: React.FC = () => {
       if (findChain && notFindChain) {
         setDropdownValue(findChain);
         dispatch(actions.updateSelectedFromChain(findChain));
-        dispatch(actions.updateSelectedToChain(notFindChain[0]));
+        // dispatch(actions.updateSelectedToChain(notFindChain[0]));
       }
     }
     // setDropdownValue(sendState.currentlySelectedFromChain);
-  }, [
-    chainId,
-    sendState.currentlySelectedFromChain,
-    sendState.currentlySelectedToChain,
-  ]);
+  }, [chainId, sendState.fromChain, dispatch]);
 
   const wrongNetworkSend =
     provider &&

--- a/src/components/ChainSelection/ChainSelection.tsx
+++ b/src/components/ChainSelection/ChainSelection.tsx
@@ -48,7 +48,9 @@ const ChainSelection: React.FC = () => {
       if (findChain && notFindChain) {
         setDropdownValue(findChain);
         dispatch(actions.updateSelectedFromChain(findChain));
-        dispatch(actions.updateSelectedToChain(notFindChain[0]));
+        dispatch(
+          actions.updateSelectedToChain(notFindChain[notFindChain.length - 1])
+        );
       }
     } else {
       setDropdownValue(sendState.currentlySelectedFromChain);

--- a/src/components/ChainSelection/ChainSelection.tsx
+++ b/src/components/ChainSelection/ChainSelection.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { onboard } from "utils";
 import { useConnection } from "state/hooks";
 import { CHAINS, switchChain, ChainId, UnsupportedChainIdError } from "utils";
@@ -24,8 +24,31 @@ const ChainSelection: React.FC = () => {
   const { init } = onboard;
   const { isConnected, provider, chainId, error } = useConnection();
   const sendState = useAppSelector((state) => state.send);
-
+  console.log("sendState", sendState, "chainidUseConn", chainId);
   const dispatch = useAppDispatch();
+
+  const [dropdownValue, setDropdownValue] = useState(
+    sendState.currentlySelectedFromChain
+  );
+
+  useEffect(() => {
+    if (chainId !== sendState.fromChain) {
+      const findChain = CHAINS_SELECTION.find((x) => x.chainId === chainId);
+      const notFindChain = CHAINS_SELECTION.filter(
+        (x) => x.chainId !== chainId
+      );
+      if (findChain && notFindChain) {
+        setDropdownValue(findChain);
+        dispatch(actions.updateSelectedFromChain(findChain));
+        dispatch(actions.updateSelectedToChain(notFindChain[0]));
+      }
+    }
+    // setDropdownValue(sendState.currentlySelectedFromChain);
+  }, [
+    chainId,
+    sendState.currentlySelectedFromChain,
+    sendState.currentlySelectedToChain,
+  ]);
 
   const wrongNetworkSend =
     provider &&
@@ -56,8 +79,8 @@ const ChainSelection: React.FC = () => {
     getMenuProps,
   } = useSelect({
     items: CHAINS_SELECTION,
-    defaultSelectedItem: sendState.currentlySelectedFromChain,
-    selectedItem: sendState.currentlySelectedFromChain,
+    defaultSelectedItem: dropdownValue,
+    selectedItem: dropdownValue,
     onSelectedItemChange: ({ selectedItem }) => {
       if (selectedItem) {
         const nextState = { ...sendState, fromChain: selectedItem.chainId };

--- a/src/components/ChainSelection/ChainSelection.tsx
+++ b/src/components/ChainSelection/ChainSelection.tsx
@@ -32,19 +32,18 @@ const ChainSelection: React.FC = () => {
   );
 
   useEffect(() => {
-    if (chainId && chainId !== sendState.fromChain) {
-      const findChain = CHAINS_SELECTION.find((x) => x.chainId === chainId);
-      const notFindChain = CHAINS_SELECTION.filter(
-        (x) => x.chainId !== chainId
-      );
-      if (findChain && notFindChain) {
-        setDropdownValue(findChain);
-        dispatch(actions.updateSelectedFromChain(findChain));
-        // dispatch(actions.updateSelectedToChain(notFindChain[0]));
-      }
-    }
-    // setDropdownValue(sendState.currentlySelectedFromChain);
-  }, [chainId, sendState.fromChain, dispatch]);
+    // if (chainId && chainId !== sendState.fromChain) {
+    //   const findChain = CHAINS_SELECTION.find((x) => x.chainId === chainId);
+    //   const notFindChain = CHAINS_SELECTION.filter(
+    //     (x) => x.chainId !== chainId
+    //   );
+    //   if (findChain && notFindChain) {
+    //     setDropdownValue(findChain);
+    //     dispatch(actions.updateSelectedFromChain(findChain));
+    //   }
+    // }
+    setDropdownValue(sendState.currentlySelectedFromChain);
+  }, [chainId, sendState.currentlySelectedFromChain, dispatch]);
 
   const wrongNetworkSend =
     provider &&
@@ -79,6 +78,7 @@ const ChainSelection: React.FC = () => {
     selectedItem: dropdownValue,
     onSelectedItemChange: ({ selectedItem }) => {
       if (selectedItem) {
+        setDropdownValue(selectedItem);
         const nextState = { ...sendState, fromChain: selectedItem.chainId };
         dispatch(actions.fromChain(nextState));
         dispatch(actions.updateSelectedFromChain(selectedItem));

--- a/src/components/ChainSelection/ChainSelection.tsx
+++ b/src/components/ChainSelection/ChainSelection.tsx
@@ -25,7 +25,6 @@ const ChainSelection: React.FC = () => {
   const { init } = onboard;
   const { isConnected, provider, chainId, error } = useConnection();
   const sendState = useAppSelector((state) => state.send);
-  console.log("sendState", sendState, "chainidUseConn", chainId);
   const dispatch = useAppDispatch();
 
   const [dropdownValue, setDropdownValue] = useState(

--- a/src/components/Wallet/Wallet.tsx
+++ b/src/components/Wallet/Wallet.tsx
@@ -49,7 +49,7 @@ const Wallet: FC = () => {
   if (account && !isConnected && !chainId) {
     return (
       <UnsupportedNetwork>
-        Unsupported Network. Please swap networks.
+        Unsupported Network. Please change networks.
       </UnsupportedNetwork>
     );
   }

--- a/src/hooks/usePrevious.ts
+++ b/src/hooks/usePrevious.ts
@@ -1,0 +1,14 @@
+// For getting the ref of a value.
+// If you need to know what the previous value of any state variable you're tracking
+// Pass it into here and you can do a comparison to the current value.
+// IE: const prevValue = useRef(value) === value ? x : y;
+
+import { useEffect, useRef } from "react";
+
+export default function usePrevious<T>(value: T): T {
+  const ref = useRef(value);
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+}


### PR DESCRIPTION
Agreed work around: we still keep a default value, but we try to shift the dropdowns in Send to what the user has specified in their connected wallet the first time they connect, and the app will ask them to switch networks after.