### PR TITLE
feat: add hex referrer tagging to across bridge txs

### DIFF
--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useEffect, useState, useContext } from "react";
 import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
+import { useLocation } from "react-router-dom";
 import useInterval from "@use-it/interval";
 import { ethers, BigNumber } from "ethers";
 import { bindActionCreators } from "redux";
@@ -13,6 +14,7 @@ import {
   MAX_APPROVAL_AMOUNT,
   optimismErc20Pairs,
   bobaErc20Pairs,
+  tagHex,
 } from "utils";
 import type { RootState, AppDispatch } from "./";
 import { ErrorContext } from "context/ErrorContext";
@@ -40,6 +42,14 @@ const FEE_ESTIMATION = "0.004";
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
 export const useAppDispatch = () => useDispatch<AppDispatch>();
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
+
+function useQuery() {
+  const { search } = useLocation();
+  return useMemo(() => {
+    const params = new URLSearchParams(search);
+    return Object.fromEntries(params.entries());
+  }, [search]);
+}
 
 export function useConnection() {
   const { account, signer, provider, error, chainId, notify } = useAppSelector(
@@ -167,6 +177,7 @@ export function useSend() {
   };
 }
 export function useSendAcross() {
+  const { referrer } = useQuery();
   const { isConnected, chainId, account, signer } = useConnection();
   const {
     fromChain,
@@ -279,15 +290,25 @@ export function useSendAcross() {
       const { instantRelayFee, slowRelayFee } = fees;
       let timestamp = block.timestamp;
 
-      const tx = await depositBox.deposit(
+      const data = depositBox.interface.encodeFunctionData("deposit", [
         toAddress,
         l2Token,
         amount,
         slowRelayFee.pct,
         instantRelayFee.pct,
         timestamp,
-        { value }
-      );
+      ]);
+
+      // do not tag a referrer if data is not provided as a hex string.
+      const taggedData =
+        referrer && ethers.utils.isHexString(referrer)
+          ? tagHex(data, referrer)
+          : data;
+      const tx = await signer.sendTransaction({
+        data: taggedData,
+        value,
+        to: depositBox.address,
+      });
       return { tx, fees };
     } catch (e) {
       throw new TransactionError(
@@ -311,6 +332,7 @@ export function useSendAcross() {
     signer,
     toAddress,
     token,
+    referrer,
   ]);
 
   return {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,4 +1,5 @@
 import { ethers } from "ethers";
+import assert from "assert";
 
 export function isValidString(s: string | null | undefined | ""): s is string {
   if (s != null && typeof s === "string" && s !== "") {
@@ -46,4 +47,19 @@ export function parseUnits(value: string, decimals: number): ethers.BigNumber {
 
 export function parseEther(value: string): ethers.BigNumber {
   return parseUnits(value, 18);
+}
+
+export function stringToHex(value: string) {
+  return ethers.utils.hexlify(ethers.utils.toUtf8Bytes(value));
+}
+
+// appends hex tag to data
+export function tagHex(dataHex: string, tagHex: string) {
+  assert(ethers.utils.isHexString(dataHex), "Data must be valid hex string");
+  return ethers.utils.hexConcat([dataHex, tagHex]);
+}
+
+// converts a string tag to hex and appends
+export function tagString(dataHex: string, tagString: string) {
+  return ethers.utils.hexConcat([dataHex, stringToHex(tagString)]);
 }


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

This allows us to make referral urls based on a hex string. The string needs to pass ethers verification as hex, otherwise the referral string will be ignored.  This also only applies to across transactions.
example: `across.to?referrer=0x9A8f92a8...16b04D`. This is the case where an address is used as the referrer tag. 

This was tested with a transaction from boba to mainnet.  https://blockexplorer.boba.network/tx/0xfacea4ec9de19b3636cf085609a94b4b6f7a32bdd56913f43969b439da74697d/internal-transactions

and was detected by the relayer
``` 
[info] across-relayer (MulticallBundler#sendTransaction)⭢Relay instantly sent :rocket:
Relayed depositId 153 on boba of 0.1200 WETH sent from [0x9A8...16b04D](https://blockexplorer.boba.network/address/0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D) to [0x9A8...16b04D](https://etherscan.io/address/0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D). slowRelayFee 21.74%, instantRelayFee 2.71%, realizedLpFee 0.09387%. Expected relay profit of 0.02934 ETH for Instant relay, with a relayerDiscount of 100%. tx [0x17f...027379](https://etherscan.io/tx/0x17f85c0e53a73cf3e5f780796a157c4803649069e47fc0830e8b7c55f6027379)
```

The "tag" is appended to the end of the data in the transaction.
```0xc2d9dca90000000000000000000000009a8f92a830a5cb89a3816e3d267cb7791c16b04d000000000000000000000000deaddeaddeaddeaddeaddeaddeaddeaddead000000000000000000000000000000000000000000000000000001aa535d3d0c00000000000000000000000000000000000000000000000000000304671b1795e71e00000000000000000000000000000000000000000000000000605f9fa8db5184000000000000000000000000000000000000000000000000000000006213de9f9a8f92a830a5cb89a3816e3d267cb7791c16b04d```

we currently do not have a specific format to follow when tagging, so this will pass all hex strings through. 