### PR TITLE
fix: checksum limits l1 token address 

### DIFF
--- a/api/limits.js
+++ b/api/limits.js
@@ -15,9 +15,12 @@ const handler = async (request, response) => {
     );
 
     let { l1Token } = request.query;
+    if (!isString(l1Token)) {
+      throw new InputError("Must provide l1Token");
+    }
+
     const checksumL1Token = ethers.utils.getAddress(l1Token);
 
-    if (!isString(checksumL1Token)) throw new InputError("Must provide l1Token");
 
     const bridgePool = BridgePoolEthers__factory.connect(
       (await getTokenDetails(provider, checksumL1Token)).bridgePool,
@@ -53,7 +56,8 @@ const handler = async (request, response) => {
     const responseJson = {
       minDeposit: ethers.BigNumber.from(depositFeeDetails.slow.total)
         .add(depositFeeDetails.instant.total)
-        .mul(4).toString(), // Max fee pct is 25%
+        .mul(4)
+        .toString(), // Max fee pct is 25%
       maxDeposit: liquidReserves.sub(pendingReserves).toString(),
     };
 

--- a/src/components/AddressSelection/AddressSelection.tsx
+++ b/src/components/AddressSelection/AddressSelection.tsx
@@ -33,7 +33,7 @@ import { useAppDispatch, useAppSelector } from "state/hooks";
 import { actions } from "state/send";
 import { AnimatePresence } from "framer-motion";
 
-import { useMatomo  } from "@datapunt/matomo-tracker-react";
+import { useMatomo } from "@datapunt/matomo-tracker-react";
 
 const AddressSelection: React.FC = () => {
   const { isConnected } = useConnection();
@@ -60,9 +60,11 @@ const AddressSelection: React.FC = () => {
     onSelectedItemChange: ({ selectedItem }) => {
       if (selectedItem) {
         // Matomo track toChain selection
-        trackEvent(
-          {category: "send", action: "setToChain", name: selectedItem.chainId.toString()}
-        );
+        trackEvent({
+          category: "send",
+          action: "setToChain",
+          name: selectedItem.chainId.toString(),
+        });
 
         const nextState = { ...sendState, toChain: selectedItem.chainId };
         dispatch(actions.toChain(nextState));

--- a/src/components/CoinSelection/CoinSelection.tsx
+++ b/src/components/CoinSelection/CoinSelection.tsx
@@ -30,7 +30,7 @@ import {
 import { AnimatePresence } from "framer-motion";
 
 // Matomo import
-import { useMatomo  } from "@datapunt/matomo-tracker-react";
+import { useMatomo } from "@datapunt/matomo-tracker-react";
 
 const FEE_ESTIMATION = ".004";
 const CoinSelection = () => {
@@ -113,9 +113,11 @@ const CoinSelection = () => {
     onSelectedItemChange: ({ selectedItem }) => {
       if (selectedItem) {
         // Matomo track token selection
-        trackEvent(
-          {category: "send", action: "setAsset", name: selectedItem.symbol}
-        );
+        trackEvent({
+          category: "send",
+          action: "setAsset",
+          name: selectedItem.symbol,
+        });
 
         setInputAmount("");
         // since we are resetting input to 0, reset any errors

--- a/src/components/Wallet/Wallet.tsx
+++ b/src/components/Wallet/Wallet.tsx
@@ -1,4 +1,4 @@
-import { useMatomo  } from "@datapunt/matomo-tracker-react";
+import { useMatomo } from "@datapunt/matomo-tracker-react";
 import { onboard } from "utils";
 import { FC, useEffect, useState, useRef } from "react";
 import { useConnection, useETHBalance } from "state/hooks";
@@ -47,16 +47,16 @@ const Wallet: FC = () => {
   const initWithMatomo = () => {
     // Matomo track wallet connect
     // TODO: Eventually add address to `name` field
-    trackEvent({category: "wallet", action: "connect", name: "null"});
+    trackEvent({ category: "wallet", action: "connect", name: "null" });
     init();
-  }
+  };
 
   const disconnectWithMatomo = () => {
     // Matomo track wallet disconnect
     // TODO: Eventually add address to `name` field
-    trackEvent({category: "wallet", action: "disconnect", name: "null"});
-    disconnectWallet()
-  }
+    trackEvent({ category: "wallet", action: "disconnect", name: "null" });
+    disconnectWallet();
+  };
 
   const { data: balance } = useETHBalance(
     { account: account ?? "", chainId: chainId ?? DEFAULT_FROM_CHAIN_ID },
@@ -72,7 +72,9 @@ const Wallet: FC = () => {
   }
 
   if (!isConnected) {
-    return <ConnectButton onClick={initWithMatomo}>Connect Wallet</ConnectButton>;
+    return (
+      <ConnectButton onClick={initWithMatomo}>Connect Wallet</ConnectButton>
+    );
   }
 
   return (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import { MatomoProvider, createInstance } from '@datapunt/matomo-tracker-react'
+import { MatomoProvider, createInstance } from "@datapunt/matomo-tracker-react";
 import React from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
@@ -13,12 +13,12 @@ const instance = createInstance({
   urlBase: "https://across.matomo.cloud",
   siteId: 1,
   linkTracking: true,
-  trackerUrl: 'https://across.matomo.cloud/matomo.php',
-})
+  trackerUrl: "https://across.matomo.cloud/matomo.php",
+});
 
 ReactDOM.render(
   <React.StrictMode>
-  <GlobalStyles />
+    <GlobalStyles />
     <Provider store={store}>
       <ErrorProvider>
         <MatomoProvider value={instance}>


### PR DESCRIPTION
Checksum the address of the l1Token to avoid API errors being thrown.

Ignore the changes coming from running the linting script. 